### PR TITLE
fix(ui): add sizes prop and priority to next/image components

### DIFF
--- a/app/menu/[id]/page.tsx
+++ b/app/menu/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function MenuPage({ params }: Props) {
       <div className="max-w-6xl w-full p-4 flex flex-col gap-2">
         <AspectRatio className="bg-muted rounded-lg overflow-hidden" ratio={16 / 5}>
           {vendor.image_url && (
-            <Image src={vendor.image_url} alt={vendor.name} fill className="object-cover" priority />
+            <Image src={vendor.image_url} alt={vendor.name} fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" priority />
           )}
         </AspectRatio>
         <div className="flex items-center gap-3 mt-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ export default async function HomePage({ searchParams }: Props) {
                 <div className="hover:scale-[1.02] transition-all duration-200 w-full flex flex-col gap-3">
                   <AspectRatio className="bg-muted rounded-lg overflow-hidden" ratio={16 / 9}>
                     {vendor.image_url && (
-                      <Image src={vendor.image_url} alt={vendor.name} fill className="object-cover" />
+                      <Image src={vendor.image_url} alt={vendor.name} fill sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw" className="object-cover" priority />
                     )}
                   </AspectRatio>
                   <div className="flex flex-col gap-1">

--- a/components/image-upload.tsx
+++ b/components/image-upload.tsx
@@ -43,7 +43,7 @@ export function ImageUpload({ bucket, path, currentUrl, onUploaded, aspectRatio 
     <div className={`${aspectRatio} relative`}>
       {/* 圖片 / 佔位區 */}
       <div className="absolute inset-0 bg-muted rounded-lg overflow-hidden">
-        {preview && <Image src={preview} alt="圖片" fill className="object-cover rounded-lg" />}
+        {preview && <Image src={preview} alt="圖片" fill sizes="(max-width: 768px) 100vw, 400px" className="object-cover rounded-lg" />}
 
         {/* 無圖片時的預設狀態 */}
         {!preview && !uploading && (


### PR DESCRIPTION
## Summary
- 首頁商家圖片加 `priority` + `sizes`（修 LCP 警告）
- 菜單頁、圖片上傳元件的 fill image 加 `sizes`

## Test plan
- [ ] Console 無 next/image 警告

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)