### PR TITLE
chore: add error boundaries and not-found page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,19 @@
 - 每個路由都有 `loading.tsx` skeleton
 - 角色系統（user / vendor / admin，一人可多角色）
 - 商家路由守衛（role-based layout）
+- 錯誤處理（error.tsx / global-error.tsx / not-found.tsx）
+- CI pipeline（GitHub Actions：lint + build + e2e test）
+- Playwright e2e 測試（首頁、菜單、訂單流程）
 
 ## 尚未實作
 
 | 分類 | 功能 | 對應需求 |
 |------|------|----------|
-| 員工端 | 訂單紀錄頁（歷史訂單查詢） | 基本需求 |
-| 員工端 | 結帳確認流程（pending → confirmed） | 基本需求 |
 | 員工端 | 餐點推薦引擎（天氣 / 銷量 / 營養） | 基本需求 |
-| 領餐 | 配送標籤產生 + 員工證掃碼領餐 | 基本需求 |
+| 領餐 | 配送標籤列印（多種印表機格式） | 基本需求 |
 | 管理員 | 福委會後台（商家審核、營運數據） | 進階需求 |
 | 管理員 | 多廠區商家服務範圍管理 | 進階需求 |
 | 帳務 | 月結帳款報表 + 薪資扣款整合 | 進階需求 |
-| 品質 | 測試（unit / integration / e2e） | 評分 25% |
-| 品質 | 錯誤處理 + 監控 | 評分 10% |
 
 ## 開始開發
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center justify-center">
+      <div className="flex flex-col items-center gap-4">
+        <p className="text-6xl font-bold">500</p>
+        <p className="text-muted-foreground">發生錯誤，請稍後再試</p>
+        <Button onClick={reset}>重試</Button>
+      </div>
+    </main>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="zh-TW">
+      <body className="min-h-dvh flex flex-col items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <p className="text-6xl font-bold">500</p>
+          <p className="text-gray-500">系統發生嚴重錯誤</p>
+          <button
+            onClick={reset}
+            className="px-4 py-2 bg-black text-white rounded-lg"
+          >
+            重試
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,16 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center justify-center">
+      <div className="flex flex-col items-center gap-4">
+        <p className="text-6xl font-bold">404</p>
+        <p className="text-muted-foreground">找不到這個頁面</p>
+        <Link href="/">
+          <Button>回首頁</Button>
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增 `error.tsx`（頁面錯誤 boundary + 重試按鈕）
- 新增 `global-error.tsx`（根層級錯誤 boundary）
- 新增 `not-found.tsx`（404 頁面）
- 同步 README（更新已完成/尚未實作清單）

## Test plan
- [ ] 訪問不存在的路由 → 顯示 404 頁面
- [ ] 「回首頁」按鈕正常

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)