### PR TITLE
fix(menu): 無商家區域仍顯示推薦區塊

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,19 +40,21 @@ export default async function HomePage({ searchParams }: Props) {
 
   const [{ data: vendors }, trending, nutritionPicks, randomPicks] = await Promise.all([
     query.order("name"),
-    getTrendingItems(8),
-    getNutritionPicks(8),
-    getRandomPicks(user?.id ?? null, 8),
+    getTrendingItems(8, area),
+    getNutritionPicks(8, area),
+    getRandomPicks(user?.id ?? null, 8, area),
   ]);
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
       <div className="max-w-6xl w-full p-4 flex flex-col gap-8">
-        <div className="flex flex-col gap-6">
-          <RecommendationSection title="🔥 熱銷排行" items={trending} />
-          <RecommendationSection title="💪 營養推薦" items={nutritionPicks} />
-          <RecommendationSection title="🎲 隨機探索" items={randomPicks} />
-        </div>
+        {(trending.length > 0 || nutritionPicks.length > 0 || randomPicks.length > 0) && (
+          <div className="flex flex-col gap-6">
+            {trending.length > 0 && <RecommendationSection title="🔥 熱銷排行" items={trending} />}
+            {nutritionPicks.length > 0 && <RecommendationSection title="💪 營養推薦" items={nutritionPicks} />}
+            {randomPicks.length > 0 && <RecommendationSection title="🎲 隨機探索" items={randomPicks} />}
+          </div>
+        )}
         {vendors && vendors.length === 0 && (
           <p className="text-muted-foreground text-center py-16">
             {area ? "此校區目前沒有合作商家" : "請先選擇校區"}

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -12,7 +12,7 @@ export type RecommendedItem = {
   vendor_name: string;
 };
 
-export async function getTrendingItems(limit = 8): Promise<RecommendedItem[]> {
+export async function getTrendingItems(limit = 8, areaId?: string): Promise<RecommendedItem[]> {
   const supabase = await createClient();
   const since = new Date(new Date().getTime() - 7 * 86400000).toISOString();
 
@@ -36,11 +36,19 @@ export async function getTrendingItems(limit = 8): Promise<RecommendedItem[]> {
 
   if (topIds.length === 0) return [];
 
-  const { data: items } = await supabase
+  const select = areaId
+    ? "id, name, price, description, tags, calories, protein, vendor_id, vendors!inner(name, vendor_areas!inner(area_id))"
+    : "id, name, price, description, tags, calories, protein, vendor_id, vendors(name)";
+
+  let query = supabase
     .from("menu_items")
-    .select("id, name, price, description, tags, calories, protein, vendor_id, vendors(name)")
+    .select(select)
     .in("id", topIds)
     .eq("is_available", true);
+
+  if (areaId) query = query.eq("vendors.vendor_areas.area_id", areaId);
+
+  const { data: items } = await query;
 
   if (!items) return [];
 
@@ -64,16 +72,24 @@ export async function getTrendingItems(limit = 8): Promise<RecommendedItem[]> {
     .filter((x): x is RecommendedItem => x !== null);
 }
 
-export async function getNutritionPicks(limit = 8): Promise<RecommendedItem[]> {
+export async function getNutritionPicks(limit = 8, areaId?: string): Promise<RecommendedItem[]> {
   const supabase = await createClient();
 
-  const { data: items } = await supabase
+  const select = areaId
+    ? "id, name, price, description, tags, calories, protein, vendor_id, vendors!inner(name, vendor_areas!inner(area_id))"
+    : "id, name, price, description, tags, calories, protein, vendor_id, vendors(name)";
+
+  let query = supabase
     .from("menu_items")
-    .select("id, name, price, description, tags, calories, protein, vendor_id, vendors(name)")
+    .select(select)
     .eq("is_available", true)
     .not("protein", "is", null)
     .order("protein", { ascending: false })
     .limit(limit);
+
+  if (areaId) query = query.eq("vendors.vendor_areas.area_id", areaId);
+
+  const { data: items } = await query;
 
   if (!items) return [];
 
@@ -93,7 +109,7 @@ export async function getNutritionPicks(limit = 8): Promise<RecommendedItem[]> {
   });
 }
 
-export async function getRandomPicks(userId: string | null, limit = 8): Promise<RecommendedItem[]> {
+export async function getRandomPicks(userId: string | null, limit = 8, areaId?: string): Promise<RecommendedItem[]> {
   const supabase = await createClient();
 
   let excludeIds: string[] = [];
@@ -107,11 +123,17 @@ export async function getRandomPicks(userId: string | null, limit = 8): Promise<
     }
   }
 
+  const select = areaId
+    ? "id, name, price, description, tags, calories, protein, vendor_id, vendors!inner(name, vendor_areas!inner(area_id))"
+    : "id, name, price, description, tags, calories, protein, vendor_id, vendors(name)";
+
   let query = supabase
     .from("menu_items")
-    .select("id, name, price, description, tags, calories, protein, vendor_id, vendors(name)")
+    .select(select)
     .eq("is_available", true)
     .order("created_at");
+
+  if (areaId) query = query.eq("vendors.vendor_areas.area_id", areaId);
 
   if (excludeIds.length > 0) {
     query = query.not("id", "in", `(${excludeIds.join(",")})`);


### PR DESCRIPTION
## Summary
- 推薦函式（熱銷、營養、隨機）加入 `areaId` 參數，透過 `vendors!inner → vendor_areas!inner` 篩選該區域的餐點
- 推薦結果為空時隱藏對應區塊，不再顯示空的推薦列

## Test plan
- [ ] 選擇有商家的區域 → 推薦區塊正常顯示該區域餐點
- [ ] 選擇無商家的區域 → 推薦區塊全部隱藏，只顯示「此校區目前沒有合作商家」
- [ ] 不選區域 → 推薦區塊顯示全站餐點

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)