### PR TITLE
fix(security): Server Action auth guards + N+1 query + open redirect

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 
 export type DashboardStats = {
   thisMonth: { orders: number; revenue: number };
@@ -20,7 +20,7 @@ function monthRange(year: number, month: number): { start: string; end: string }
 }
 
 export async function getDashboardStats(): Promise<DashboardStats> {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const now = new Date();
   const thisMonth = monthRange(now.getFullYear(), now.getMonth());
   const lastMonth = monthRange(now.getFullYear(), now.getMonth() - 1);
@@ -67,7 +67,7 @@ export async function getDashboardStats(): Promise<DashboardStats> {
 }
 
 export async function getOrderTrend(days: number): Promise<DailyOrderCount[]> {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const now = new Date();
   const start = new Date(now.getTime() - (days - 1) * 86400000).toISOString().slice(0, 10);
 
@@ -92,7 +92,7 @@ export async function getOrderTrend(days: number): Promise<DailyOrderCount[]> {
 }
 
 export async function getTopVendors(limit: number): Promise<RankedItem[]> {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
 
   const { data } = await supabase
     .from("order_items")
@@ -123,7 +123,7 @@ export async function getTopVendors(limit: number): Promise<RankedItem[]> {
 }
 
 export async function getTopMenuItems(limit: number): Promise<RankedItem[]> {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
 
   const { data } = await supabase
     .from("order_items")

--- a/app/admin/reports/actions.ts
+++ b/app/admin/reports/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 
 export type VendorReport = {
   vendor_id: string;
@@ -10,7 +10,7 @@ export type VendorReport = {
 };
 
 export async function getMonthlyReport(year: number, month: number): Promise<VendorReport[]> {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
 
   const startDate = new Date(year, month - 1, 1).toISOString();
   const endDate = new Date(year, month, 0, 23, 59, 59).toISOString();

--- a/app/admin/vendors/actions.ts
+++ b/app/admin/vendors/actions.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 
 export async function approveVendor(vendorId: string, areaIds: string[]) {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const { error } = await supabase
     .from("vendors")
     .update({ status: "approved", is_active: true })
@@ -24,7 +24,7 @@ export async function approveVendor(vendorId: string, areaIds: string[]) {
 }
 
 export async function rejectVendor(vendorId: string) {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const { error } = await supabase
     .from("vendors")
     .update({ status: "rejected", is_active: false })
@@ -36,7 +36,7 @@ export async function rejectVendor(vendorId: string) {
 }
 
 export async function suspendVendor(vendorId: string) {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const { error } = await supabase
     .from("vendors")
     .update({ status: "suspended", is_active: false })
@@ -48,7 +48,7 @@ export async function suspendVendor(vendorId: string) {
 }
 
 export async function reactivateVendor(vendorId: string) {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const { error } = await supabase
     .from("vendors")
     .update({ status: "approved", is_active: true })
@@ -60,7 +60,7 @@ export async function reactivateVendor(vendorId: string) {
 }
 
 export async function updateVendorAreas(vendorId: string, areaIds: string[]) {
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   await supabase.from("vendor_areas").delete().eq("vendor_id", vendorId);
   if (areaIds.length > 0) {
     await supabase

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -4,7 +4,8 @@ import { NextResponse } from "next/server";
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  const raw = searchParams.get("next") ?? "/";
+  const next = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/";
 
   if (code) {
     const supabase = await createClient();

--- a/app/orders/actions.ts
+++ b/app/orders/actions.ts
@@ -44,34 +44,40 @@ export async function getOrders(
   const hasMore = orders.length > limit;
   const pageOrders = hasMore ? orders.slice(0, limit) : orders;
 
-  const result: OrderSummary[] = [];
-  for (const order of pageOrders) {
-    const { data: items } = await supabase
-      .from("order_items")
-      .select(
-        "id, date, qty, unit_price, picked_up, menu_items(name, vendors(name)), order_item_options(name, price_delta)"
-      )
-      .eq("order_id", order.id)
-      .order("date");
+  const orderIds = pageOrders.map((o) => o.id);
 
-    result.push({
-      id: order.id,
-      status: order.status,
-      created_at: order.created_at,
-      items: (items ?? []).map((i) => ({
-        id: i.id,
-        date: i.date,
-        qty: i.qty,
-        unit_price: i.unit_price,
-        picked_up: i.picked_up,
-        menu_item_name: (i.menu_items as { name: string } | null)?.name ?? "",
-        vendor_name:
-          (i.menu_items as { vendors: { name: string } | null } | null)
-            ?.vendors?.name ?? "",
-        options: (i.order_item_options as { name: string; price_delta: number }[]) ?? [],
-      })),
-    });
+  const { data: allItems } = await supabase
+    .from("order_items")
+    .select(
+      "id, date, qty, unit_price, picked_up, order_id, menu_items(name, vendors(name)), order_item_options(name, price_delta)"
+    )
+    .in("order_id", orderIds)
+    .order("date");
+
+  const itemsByOrder = new Map<string, typeof allItems>();
+  for (const item of allItems ?? []) {
+    const list = itemsByOrder.get(item.order_id) ?? [];
+    list.push(item);
+    itemsByOrder.set(item.order_id, list);
   }
+
+  const result: OrderSummary[] = pageOrders.map((order) => ({
+    id: order.id,
+    status: order.status,
+    created_at: order.created_at,
+    items: (itemsByOrder.get(order.id) ?? []).map((i) => ({
+      id: i.id,
+      date: i.date,
+      qty: i.qty,
+      unit_price: i.unit_price,
+      picked_up: i.picked_up,
+      menu_item_name: (i.menu_items as { name: string } | null)?.name ?? "",
+      vendor_name:
+        (i.menu_items as { vendors: { name: string } | null } | null)
+          ?.vendors?.name ?? "",
+      options: (i.order_item_options as { name: string; price_delta: number }[]) ?? [],
+    })),
+  }));
 
   return { orders: result, hasMore };
 }

--- a/app/vendor/menu/actions.ts
+++ b/app/vendor/menu/actions.ts
@@ -1,7 +1,29 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
+
+async function requireVendor() {
+  const { user, supabase } = await requireRole("vendor");
+  const { data: vendor } = await supabase
+    .from("vendors")
+    .select("id")
+    .eq("owner_id", user.id)
+    .single();
+  if (!vendor) throw new Error("找不到商家");
+  return { supabase, vendor };
+}
+
+async function requireMenuItemOwnership(supabase: Awaited<ReturnType<typeof createClient>>, vendorId: string, menuItemId: string) {
+  const { data } = await supabase
+    .from("menu_items")
+    .select("id")
+    .eq("id", menuItemId)
+    .eq("vendor_id", vendorId)
+    .single();
+  if (!data) throw new Error("權限不足");
+}
 
 export async function upsertMenuItem(data: {
   id?: string;
@@ -15,16 +37,7 @@ export async function upsertMenuItem(data: {
   sugar?: number;
   tags?: string[];
 }) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: "未登入" };
-
-  const { data: vendor } = await supabase
-    .from("vendors")
-    .select("id")
-    .eq("owner_id", user.id)
-    .single();
-  if (!vendor) return { error: "找不到商家" };
+  const { supabase, vendor } = await requireVendor();
 
   const { error } = data.id
     ? await supabase.from("menu_items").update({ ...data, vendor_id: vendor.id }).eq("id", data.id)
@@ -36,7 +49,8 @@ export async function upsertMenuItem(data: {
 }
 
 export async function setDailySlot(menuItemId: string, date: string, maxQty: number) {
-  const supabase = await createClient();
+  const { supabase, vendor } = await requireVendor();
+  await requireMenuItemOwnership(supabase, vendor.id, menuItemId);
 
   const { error } = await supabase
     .from("daily_slots")
@@ -48,8 +62,8 @@ export async function setDailySlot(menuItemId: string, date: string, maxQty: num
 }
 
 export async function toggleMenuItem(id: string, isAvailable: boolean) {
-  const supabase = await createClient();
-  await supabase.from("menu_items").update({ is_available: isAvailable }).eq("id", id);
+  const { supabase, vendor } = await requireVendor();
+  await supabase.from("menu_items").update({ is_available: isAvailable }).eq("id", id).eq("vendor_id", vendor.id);
   revalidatePath("/vendor/menu");
 }
 
@@ -61,7 +75,8 @@ export async function upsertOptionGroup(data: {
   max_select: number;
   sort_order: number;
 }) {
-  const supabase = await createClient();
+  const { supabase, vendor } = await requireVendor();
+  await requireMenuItemOwnership(supabase, vendor.id, data.menu_item_id);
   const { error } = data.id
     ? await supabase.from("item_option_groups").update(data).eq("id", data.id)
     : await supabase.from("item_option_groups").insert(data);
@@ -71,7 +86,13 @@ export async function upsertOptionGroup(data: {
 }
 
 export async function deleteOptionGroup(id: string) {
-  const supabase = await createClient();
+  const { supabase, vendor } = await requireVendor();
+  const { data: group } = await supabase
+    .from("item_option_groups")
+    .select("menu_item_id")
+    .eq("id", id)
+    .single();
+  if (group) await requireMenuItemOwnership(supabase, vendor.id, group.menu_item_id);
   await supabase.from("item_option_groups").delete().eq("id", id);
   revalidatePath("/vendor/menu");
 }
@@ -83,7 +104,14 @@ export async function upsertOption(data: {
   price_delta: number;
   sort_order: number;
 }) {
-  const supabase = await createClient();
+  const { supabase, vendor } = await requireVendor();
+  const { data: group } = await supabase
+    .from("item_option_groups")
+    .select("menu_item_id")
+    .eq("id", data.group_id)
+    .single();
+  if (!group) return { error: "找不到選項群組" };
+  await requireMenuItemOwnership(supabase, vendor.id, group.menu_item_id);
   const { error } = data.id
     ? await supabase.from("item_options").update(data).eq("id", data.id)
     : await supabase.from("item_options").insert(data);
@@ -93,18 +121,22 @@ export async function upsertOption(data: {
 }
 
 export async function deleteOption(id: string) {
-  const supabase = await createClient();
+  const { supabase, vendor } = await requireVendor();
+  const { data: option } = await supabase
+    .from("item_options")
+    .select("group_id, item_option_groups(menu_item_id)")
+    .eq("id", id)
+    .single();
+  if (option) {
+    const group = option.item_option_groups as { menu_item_id: string } | null;
+    if (group) await requireMenuItemOwnership(supabase, vendor.id, group.menu_item_id);
+  }
   await supabase.from("item_options").delete().eq("id", id);
   revalidatePath("/vendor/menu");
 }
 
 export async function deleteMenuItem(id: string) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: "未登入" };
-
-  const { data: vendor } = await supabase.from("vendors").select("id").eq("owner_id", user.id).single();
-  if (!vendor) return { error: "找不到商家" };
+  const { supabase, vendor } = await requireVendor();
 
   const { error } = await supabase.from("menu_items").delete().eq("id", id).eq("vendor_id", vendor.id);
   if (error) return { error: error.message };

--- a/app/vendor/profile/actions.ts
+++ b/app/vendor/profile/actions.ts
@@ -1,12 +1,10 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 
 export async function updateVendorInfo(formData: FormData) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: "未登入" };
+  const { user, supabase } = await requireRole("vendor");
 
   const name = (formData.get("name") as string).trim();
   const description = (formData.get("description") as string).trim();
@@ -28,9 +26,7 @@ export async function updateVendorInfo(formData: FormData) {
 }
 
 export async function updateVendorSchedule(isOpen: boolean, operatingDays: number[]) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: "未登入" };
+  const { user, supabase } = await requireRole("vendor");
 
   await supabase
     .from("vendors")
@@ -43,9 +39,7 @@ export async function updateVendorSchedule(isOpen: boolean, operatingDays: numbe
 }
 
 export async function updateVendorImage(imageUrl: string) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: "未登入" };
+  const { user, supabase } = await requireRole("vendor");
 
   await supabase.from("vendors").update({ image_url: imageUrl }).eq("owner_id", user.id);
   revalidatePath("/vendor/profile");

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,19 @@
+import { createClient } from "@/lib/supabase/server";
+
+type Role = "admin" | "vendor" | "user";
+
+export async function requireRole(role: Role) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("未登入");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.role?.includes(role)) throw new Error("權限不足");
+
+  return { user, supabase };
+}


### PR DESCRIPTION
## Summary
- **#25** 修復 OAuth callback open redirect — 驗證 `next` 參數不含 `//`
- **#26** `getOrders` N+1 查詢改為 `.in("order_id", ids)` 批次查詢（11 次 → 2 次）
- **#27** vendor menu actions（`setDailySlot`、`upsertOptionGroup` 等）加入所有權驗證
- **#28** 所有 admin Server Actions 加入 `requireRole("admin")` guard
- **#29** 所有 vendor profile Server Actions 加入 `requireRole("vendor")` guard
- 新增 `lib/auth.ts` — 共用 `requireRole()` helper，統一角色檢查邏輯

## Test plan
- [ ] OAuth 登入正常導向（`?next=/orders` → 導到 `/orders`）
- [ ] `?next=//evil.com` → 導到 `/` 而非外部
- [ ] 訂單紀錄頁載入速度改善
- [ ] 一般用戶呼叫 admin/vendor actions → throw 權限不足
- [ ] vendor 操作自己的餐點 → 正常
- [ ] vendor 操作別人的餐點 → throw 權限不足

Closes #25, #26, #27, #28, #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)