### PR TITLE
fix: 修復 8 個 Important issues (#31-#38)

### DIFF
--- a/app/cart/actions.ts
+++ b/app/cart/actions.ts
@@ -5,6 +5,18 @@ import { revalidatePath } from "next/cache";
 
 export async function removeOrderItem(orderItemId: string) {
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "未登入" };
+
+  const { data: item } = await supabase
+    .from("order_items")
+    .select("id, orders!inner(user_id)")
+    .eq("id", orderItemId)
+    .single();
+
+  if (!item || (item.orders as { user_id: string } | null)?.user_id !== user.id)
+    return { error: "權限不足" };
+
   const { error } = await supabase
     .from("order_items")
     .delete()
@@ -29,6 +41,13 @@ export async function confirmOrder(orderId: string) {
 
   if (!order) return { error: "找不到預約單" };
   if (order.status !== "pending") return { error: "預約單狀態不符" };
+
+  const { data: items } = await supabase
+    .from("order_items")
+    .select("id")
+    .eq("order_id", orderId)
+    .limit(1);
+  if (!items || items.length === 0) return { error: "預約單沒有品項" };
 
   const { error } = await supabase
     .from("orders")

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -59,11 +59,7 @@ export default async function OrderDetailPage({
   const shortId = order.id.replace(/-/g, "").slice(0, 8);
   const totalItems = orderItems.reduce((sum, i) => sum + i.qty, 0);
   const totalPrice = orderItems.reduce(
-    (sum, i) =>
-      sum +
-      i.qty *
-        (i.unit_price +
-          i.options.reduce((s, o) => s + o.price_delta, 0)),
+    (sum, i) => sum + i.qty * i.unit_price,
     0
   );
 
@@ -90,10 +86,7 @@ export default async function OrderDetailPage({
 
         <div className="flex flex-col gap-3">
           {orderItems.map((item) => {
-            const itemTotal =
-              item.qty *
-              (item.unit_price +
-                item.options.reduce((s, o) => s + o.price_delta, 0));
+            const itemTotal = item.qty * item.unit_price;
             const showQr =
               order.status === "confirmed" && !item.picked_up;
 

--- a/app/vendor/orders/actions.ts
+++ b/app/vendor/orders/actions.ts
@@ -24,7 +24,12 @@ export async function pickUpOrderItem(orderItemId: string) {
   if (!item || (item.menu_items as { vendor_id: string } | null)?.vendor_id !== vendor.id)
     return { error: "此品項不屬於您" };
 
-  await supabase.from("order_items").update({ picked_up: true }).eq("id", orderItemId);
+  const { error: updateError } = await supabase
+    .from("order_items")
+    .update({ picked_up: true })
+    .eq("id", orderItemId);
+
+  if (updateError) return { error: "更新失敗" };
 
   const { data: remaining } = await supabase
     .from("order_items")
@@ -37,12 +42,15 @@ export async function pickUpOrderItem(orderItemId: string) {
   }
 
   revalidatePath("/vendor/orders");
-  return { success: true };
+  return { success: true, order_id: item.order_id };
 }
 
 export async function batchPickUp(orderItemIds: string[]) {
-  const results = await Promise.all(orderItemIds.map(pickUpOrderItem));
-  const errors = results.filter((r) => r.error);
+  const errors: string[] = [];
+  for (const id of orderItemIds) {
+    const result = await pickUpOrderItem(id);
+    if (result.error) errors.push(result.error);
+  }
   if (errors.length > 0) return { error: `${errors.length} 筆失敗` };
   return { success: true };
 }

--- a/components/image-upload.tsx
+++ b/components/image-upload.tsx
@@ -19,9 +19,23 @@ export function ImageUpload({ bucket, path, currentUrl, onUploaded, aspectRatio 
   const [preview, setPreview] = useState<string | null>(currentUrl ?? null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+  const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
   async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      alert("僅支援 JPG、PNG、WebP、GIF 格式");
+      e.target.value = "";
+      return;
+    }
+    if (file.size > MAX_SIZE) {
+      alert("檔案大小不可超過 5MB");
+      e.target.value = "";
+      return;
+    }
 
     const ext = file.name.split(".").pop();
     const filePath = `${path}/${Date.now()}.${ext}`;

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -20,7 +20,7 @@ export async function getTrendingItems(limit = 8, areaId?: string): Promise<Reco
     .from("order_items")
     .select("menu_item_id, qty, orders!inner(status, created_at)")
     .neq("orders.status", "pending")
-    .gte("created_at", since);
+    .gte("orders.created_at", since);
 
   if (!orderItems || orderItems.length === 0) return [];
 
@@ -130,8 +130,7 @@ export async function getRandomPicks(userId: string | null, limit = 8, areaId?: 
   let query = supabase
     .from("menu_items")
     .select(select)
-    .eq("is_available", true)
-    .order("created_at");
+    .eq("is_available", true);
 
   if (areaId) query = query.eq("vendors.vendor_areas.area_id", areaId);
 
@@ -139,7 +138,8 @@ export async function getRandomPicks(userId: string | null, limit = 8, areaId?: 
     query = query.not("id", "in", `(${excludeIds.join(",")})`);
   }
 
-  const { data: items } = await query;
+  // 撈 limit * 3 筆再 shuffle，避免撈整張表
+  const { data: items } = await query.limit(limit * 3);
 
   if (!items || items.length === 0) return [];
 


### PR DESCRIPTION
## Summary
- **#31** `confirmOrder` 檢查訂單至少有一個品項才能確認
- **#32** `removeOrderItem` 加入所有權驗證（join orders 確認 user_id）
- **#33** `pickUpOrderItem` 檢查 update 結果，失敗時不繼續標記訂單完成
- **#34** 熱銷排行改用 `orders.created_at` 篩選（原本用 `order_items.created_at`）
- **#35** 隨機探索加 `.limit(limit * 3)` 再 shuffle，不再撈整張表
- **#36** `batchPickUp` 改為 `for...of` sequential，避免同訂單 race condition
- **#37** 訂單詳情頁 totalPrice 和 itemTotal 移除重複的 option price_delta 計算
- **#38** 圖片上傳加入 MIME type 白名單（JPG/PNG/WebP/GIF）和 5MB 大小限制

## Test plan
- [ ] 確認空購物車無法送出訂單
- [ ] 刪除購物車品項只能刪自己的
- [ ] 商家批次領餐不會重複標記訂單完成
- [ ] 訂單詳情頁金額正確（不再重複加選項差額）
- [ ] 上傳非圖片檔案 → 被攔截

Closes #31, #32, #33, #34, #35, #36, #37, #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)