### PR TITLE
fix(admin): 營收統計排除取消訂單

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -42,10 +42,12 @@ export async function getDashboardStats(): Promise<DashboardStats> {
 
   function sumRevenue(orders: typeof thisMonthOrders["data"]) {
     if (!orders) return 0;
-    return orders.reduce((total, order) => {
-      const items = Array.isArray(order.order_items) ? order.order_items : [];
-      return total + items.reduce((s, i) => s + (i.qty ?? 0) * (i.unit_price ?? 0), 0);
-    }, 0);
+    return orders
+      .filter((o) => o.status === "completed")
+      .reduce((total, order) => {
+        const items = Array.isArray(order.order_items) ? order.order_items : [];
+        return total + items.reduce((s, i) => s + (i.qty ?? 0) * (i.unit_price ?? 0), 0);
+      }, 0);
   }
 
   function countByStatus(orders: typeof thisMonthOrders["data"], status: string) {


### PR DESCRIPTION
## Summary
- `getDashboardStats()` 的 `sumRevenue()` 只計算 `status === 'completed'` 的訂單
- 修復「本月營收」虛高問題，與月結報表邏輯對齊

## Test plan
- [ ] 建立已取消訂單，確認「本月營收」不含取消金額
- [ ] 對比 `/admin` 營收與 `/admin/reports` 月結報表數字一致

Closes #44