### PR TITLE
fix(admin): 商家管理頁面改用 requireRole 權限檢查

### DIFF
--- a/app/admin/vendors/[id]/page.tsx
+++ b/app/admin/vendors/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 import { Separator } from "@/components/ui/separator";
 import { VendorActions } from "./vendor-actions";
 import { format } from "date-fns";
@@ -20,7 +20,7 @@ export default async function VendorDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
 
   const [{ data: vendor }, { data: areas }] = await Promise.all([
     supabase

--- a/app/admin/vendors/page.tsx
+++ b/app/admin/vendors/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth";
 
 const statusConfig = {
   pending: { label: "待審核", className: "text-yellow-600 bg-yellow-50" },
@@ -21,7 +21,7 @@ export default async function AdminVendorsPage({
   const filterStatus: StatusKey =
     status && status in statusConfig ? (status as StatusKey) : "pending";
 
-  const supabase = await createClient();
+  const { supabase } = await requireRole("admin");
   const { data: vendors } = await supabase
     .from("vendors")
     .select(


### PR DESCRIPTION
## Summary
- `vendors/page.tsx` 與 `vendors/[id]/page.tsx` 改用 `requireRole("admin")` 取得 supabase client
- 與所有 Server Actions 保持一致，defense-in-depth

## Test plan
- [ ] 以 admin 帳號正常瀏覽 `/admin/vendors`
- [ ] 以非 admin 帳號嘗試存取被 redirect

Closes #45