### PR TITLE
fix(admin): 營收統計與月結報表邏輯對齊（含 confirmed）

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -43,7 +43,7 @@ export async function getDashboardStats(): Promise<DashboardStats> {
   function sumRevenue(orders: typeof thisMonthOrders["data"]) {
     if (!orders) return 0;
     return orders
-      .filter((o) => o.status === "completed")
+      .filter((o) => o.status === "confirmed" || o.status === "completed")
       .reduce((total, order) => {
         const items = Array.isArray(order.order_items) ? order.order_items : [];
         return total + items.reduce((s, i) => s + (i.qty ?? 0) * (i.unit_price ?? 0), 0);


### PR DESCRIPTION
## Summary
- #48 的修復只算 `completed`，但月結報表算 `confirmed + completed`，引入新的不一致
- 經 Playwright 實測 + Supabase 資料驗證後發現：DB 有 42 筆 confirmed 訂單 ($3585)，只有 1 筆 completed ($90)
- 修正為與 `getMonthlyReport` 邏輯一致：`confirmed | completed`，排除 `cancelled` 和 `pending`

## Test plan
- [ ] `/admin` 本月營收應與 `/admin/reports` 月結報表總計一致
- [ ] 有取消訂單時，兩頁都不含取消金額

🤖 Generated with [Claude Code](https://claude.com/claude-code)