### PR TITLE
fix(admin): AreaEditor key 穩定化，修復儲存回饋消失問題

### DIFF
--- a/app/admin/vendors/[id]/page.tsx
+++ b/app/admin/vendors/[id]/page.tsx
@@ -38,7 +38,8 @@ export default async function VendorDetailPage({
   const { data: vendorAreas } = await supabase
     .from("vendor_areas")
     .select("area_id")
-    .eq("vendor_id", id);
+    .eq("vendor_id", id)
+    .order("area_id");
 
   const selectedAreaIds = vendorAreas?.map((va) => va.area_id) ?? [];
 

--- a/app/admin/vendors/[id]/vendor-actions.tsx
+++ b/app/admin/vendors/[id]/vendor-actions.tsx
@@ -26,7 +26,7 @@ export function VendorActions({
   return (
     <>
       <AreaEditor
-        key={selectedAreaIds.join(",")}
+        key={[...selectedAreaIds].sort().join(",")}
         vendorId={vendorId}
         areas={areas}
         selectedAreaIds={selectedAreaIds}


### PR DESCRIPTION
## Summary
- Playwright 實測發現「已儲存」文字從未顯示
- 根本原因：`vendor_areas` 查詢無 ORDER BY，DB 回傳順序不固定 → key 字串每次不同 → `revalidatePath` 後 AreaEditor re-mount → `saveStatus` 重置為 idle
- `vendor-actions.tsx`：key 改用 `[...selectedAreaIds].sort().join(",")` 確保排序無關
- `[id]/page.tsx`：查詢加上 `.order("area_id")` 與前端邏輯一致

## Test plan
- [ ] 點「儲存服務區域」後出現「已儲存」綠色文字
- [ ] 修改區域後儲存，文字正確更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)