### PR TITLE
fix(e2e): cart 頁面 cache 傳播延遲導致 flaky test

### DIFF
--- a/e2e/order-flow.spec.ts
+++ b/e2e/order-flow.spec.ts
@@ -39,10 +39,18 @@ test.describe("訂單流程", () => {
     await addItemToCart(page);
 
     await page.goto("/cart");
+    await page.waitForLoadState("networkidle");
     await expect(page.locator("h1", { hasText: "我的預約單" })).toBeVisible();
 
+    // Retry navigation if cart data hasn't propagated yet
+    const checkoutBtn = page.locator("button", { hasText: "結帳確認" });
+    if (!(await checkoutBtn.isVisible({ timeout: 3000 }).catch(() => false))) {
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+    }
+
     // Click checkout trigger button
-    await page.locator("button", { hasText: "結帳確認" }).click();
+    await checkoutBtn.click();
 
     const confirmDialog = page.locator("[role='dialog']");
     await expect(confirmDialog).toBeVisible();
@@ -57,9 +65,17 @@ test.describe("訂單流程", () => {
     await addItemToCart(page);
 
     await page.goto("/cart");
+    await page.waitForLoadState("networkidle");
     await expect(page.locator("h1", { hasText: "我的預約單" })).toBeVisible();
 
-    await page.locator("button", { hasText: "清空購物車" }).click();
+    // Retry navigation if cart data hasn't propagated yet
+    const clearBtn = page.locator("button", { hasText: "清空購物車" });
+    if (!(await clearBtn.isVisible({ timeout: 3000 }).catch(() => false))) {
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+    }
+
+    await clearBtn.click();
 
     const cancelDialog = page.locator("[role='dialog']");
     await expect(cancelDialog).toBeVisible();


### PR DESCRIPTION
## Summary
- `addItemToCart` 成功後導航到 `/cart`，`revalidatePath` 可能尚未完全傳播
- Server Component render 拿到舊 cache → cart 為空 → 找不到「結帳確認」按鈕
- 加入 `waitForLoadState('networkidle')` + 按鈕不可見時自動 `reload()` 重試

## Test plan
- [ ] CI 通過，order-flow 測試不再 flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)