### PR TITLE
fix(orders): pending order 查詢改用 maybeSingle 避免多筆 crash

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -15,7 +15,9 @@ export default async function CartPage() {
     .select("id")
     .eq("user_id", user.id)
     .eq("status", "pending")
-    .single();
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
 
   const items = order
     ? (await supabase

--- a/app/menu/[id]/actions.ts
+++ b/app/menu/[id]/actions.ts
@@ -18,14 +18,16 @@ export async function addToOrder(
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: "請先登入" };
 
-  // 找或建立 pending order
+  // 找或建立 pending order（用 limit(1) 避免多筆 pending 時 .single() 報錯）
   let orderId: string;
   const { data: existing } = await supabase
     .from("orders")
     .select("id")
     .eq("user_id", user.id)
     .eq("status", "pending")
-    .single();
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
 
   if (existing) {
     orderId = existing.id;


### PR DESCRIPTION
## Summary
- `addToOrder` 和 `cart/page.tsx` 都用 `.single()` 查 pending order
- 當用戶因任何原因累積多筆 pending order（如 CI retry、concurrent requests），`.single()` 回傳 error + null
- `addToOrder` 的 `existing` 為 null → 建新 pending order → 惡性循環
- `cart/page.tsx` 的 `order` 為 null → cart 永遠顯示空
- **修復**：改用 `.order("created_at", desc).limit(1).maybeSingle()`，取最新的 pending order
- **DB 清理**：已將重複的 14 筆 pending 改為 cancelled

## Root Cause
Supabase `.single()` 在 0 筆或 2+ 筆時都回傳 `{ data: null, error }`。多筆 pending 是由 concurrent requests 或 test retry 造成。

## Test plan
- [ ] CI E2E 通過（order-flow 測試不再 flaky）
- [ ] 手動驗證：加入購物車 → cart 顯示正確

Closes #53