### PR TITLE
Software test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,6 @@
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
 
+Shared rule entrypoint for Codex. `CLAUDE.md` aggregates the project rules for Claude-compatible tooling.
+
 @CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,7 @@
-@AGENTS.md
+# Shared project rules entrypoint for Claude.
+# `AGENTS.md` may include this file for Codex compatibility.
+# Do not reference `AGENTS.md` here, or the two files will create a cycle.
+
 @.claude/rules/coding-style.md
 @.claude/rules/architecture.md
 @.claude/rules/project.md

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Campus meal ordering platform for NYCU — employees pre-order meals from partne
 - Admin dashboard (vendor approval, operations dashboard, multi-area management, monthly report CSV export)
 - Error handling (error.tsx / global-error.tsx / not-found.tsx)
 - CI pipeline (GitHub Actions: lint + build + e2e test)
+- Layered test setup:
+  - Vitest for unit tests
+  - Vitest + mocks for Server Action / query-flow integration tests
+  - Playwright for end-to-end user flows
 - Playwright e2e tests (homepage, menu, order flow)
 
 ## Not Yet Implemented
@@ -63,11 +67,32 @@ See `.env.example` for required environment variables (Supabase project config).
 ## Testing
 
 ```bash
-bun run test        # Run e2e tests (Playwright)
+bun run test        # Run Vitest first, then Playwright e2e
+bun run test:unit   # Run unit tests + mock integration tests with Vitest
+bun run test:e2e    # Run Playwright e2e tests
 bun run test:ui     # Playwright UI mode
 ```
 
-CI runs lint + build + e2e test on every PR (see `.github/workflows/ci.yml`).
+### Current Test Coverage
+
+- `app/cart/cart-view.test.ts`: cart grouping, sorting, totals
+- `app/orders/order-summary.test.ts`: order summary normalization
+- `app/cart/actions.test.ts`: mocked Server Action coverage for cart flows
+- `app/orders/actions.test.ts`: mocked order query + pagination coverage
+- `e2e/home.spec.ts`, `e2e/menu.spec.ts`, `e2e/order-flow.spec.ts`: real browser flows
+
+### E2E Requirements
+
+Playwright global setup logs in with the credentials from `.env` before tests run.
+
+Required environment variables:
+
+```bash
+E2E_EMAIL=...
+E2E_PASSWORD=...
+```
+
+CI currently runs lint + build + e2e test on every PR (see `.github/workflows/ci.yml`).
 
 ## Directory Structure
 

--- a/app/cart/actions.test.ts
+++ b/app/cart/actions.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+import { cancelOrder, confirmOrder, removeOrderItem } from "@/app/cart/actions";
+
+type QueryStep = {
+  eqResults?: Array<unknown>;
+  singleResult?: unknown;
+  limitResult?: unknown;
+};
+
+function createQuery(step: QueryStep = {}) {
+  const query: Record<string, ReturnType<typeof vi.fn>> = {};
+  let eqCallIndex = 0;
+
+  query.select = vi.fn(() => query);
+  query.eq = vi.fn(() => {
+    const value = step.eqResults?.[eqCallIndex];
+    eqCallIndex += 1;
+    return value === undefined ? query : value;
+  });
+  query.single = vi.fn(async () => step.singleResult);
+  query.limit = vi.fn(async () => step.limitResult);
+  query.update = vi.fn(() => query);
+  query.delete = vi.fn(() => query);
+
+  return query;
+}
+
+function createSupabaseMock({
+  user,
+  queries,
+}: {
+  user: { id: string } | null;
+  queries: Record<string, QueryStep[]>;
+}) {
+  const queryInstances = new Map<string, ReturnType<typeof createQuery>[]>();
+
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user },
+      })),
+    },
+    from: vi.fn((table: string) => {
+      const steps = queries[table];
+      if (!steps || steps.length === 0) {
+        throw new Error(`No query step configured for table ${table}`);
+      }
+
+      const query = createQuery(steps.shift());
+      const list = queryInstances.get(table) ?? [];
+      list.push(query);
+      queryInstances.set(table, list);
+      return query;
+    }),
+    queryInstances,
+  };
+}
+
+describe("cart server actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+  });
+
+  it("rejects checkout when the user is not logged in", async () => {
+    const supabase = createSupabaseMock({
+      user: null,
+      queries: {},
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(confirmOrder("order-1")).resolves.toEqual({ error: "未登入" });
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it("confirms a pending order with at least one item", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [
+          { singleResult: { data: { id: "order-1", status: "pending" } } },
+          { eqResults: [{ error: null }] },
+        ],
+        order_items: [{ limitResult: { data: [{ id: "item-1" }] } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(confirmOrder("order-1")).resolves.toEqual({ success: true });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/cart");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/orders");
+  });
+
+  it("refuses to confirm an empty pending order", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [{ singleResult: { data: { id: "order-1", status: "pending" } } }],
+        order_items: [{ limitResult: { data: [] } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(confirmOrder("order-1")).resolves.toEqual({
+      error: "預約單沒有品項",
+    });
+  });
+
+  it("cancels a pending order and clears its items", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [
+          { singleResult: { data: { id: "order-1", status: "pending" } } },
+          { eqResults: [{ error: null }] },
+        ],
+        order_items: [{ eqResults: [{ error: null }] }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(cancelOrder("order-1")).resolves.toEqual({ success: true });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/cart");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/orders");
+  });
+
+  it("removes an order item owned by the current user", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        order_items: [
+          {
+            singleResult: {
+              data: { id: "item-1", orders: { user_id: "user-1" } },
+            },
+          },
+          { eqResults: [{ error: null }] },
+        ],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(removeOrderItem("item-1")).resolves.toEqual({ success: true });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/cart");
+  });
+
+  it("blocks removing an item owned by another user", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        order_items: [
+          {
+            singleResult: {
+              data: { id: "item-1", orders: { user_id: "user-2" } },
+            },
+          },
+        ],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(removeOrderItem("item-1")).resolves.toEqual({
+      error: "權限不足",
+    });
+  });
+});

--- a/app/cart/cart-view.test.ts
+++ b/app/cart/cart-view.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCartViewModel } from "@/app/cart/cart-view";
+
+describe("buildCartViewModel", () => {
+  it("groups items by date, sorts dates, and computes totals", () => {
+    const result = buildCartViewModel([
+      {
+        id: "item-2",
+        date: "2026-04-02",
+        qty: 1,
+        unit_price: 80,
+      },
+      {
+        id: "item-1",
+        date: "2026-04-01",
+        qty: 2,
+        unit_price: 100,
+      },
+      {
+        id: "item-3",
+        date: "2026-04-01",
+        qty: 3,
+        unit_price: 50,
+      },
+    ]);
+
+    expect(result.dates).toEqual(["2026-04-01", "2026-04-02"]);
+    expect(result.byDate["2026-04-01"].map((item) => item.id)).toEqual([
+      "item-1",
+      "item-3",
+    ]);
+    expect(result.itemCount).toBe(3);
+    expect(result.total).toBe(430);
+  });
+
+  it("returns empty structures for an empty cart", () => {
+    expect(buildCartViewModel([])).toEqual({
+      byDate: {},
+      dates: [],
+      itemCount: 0,
+      total: 0,
+    });
+  });
+});

--- a/app/cart/cart-view.ts
+++ b/app/cart/cart-view.ts
@@ -1,0 +1,30 @@
+export type CartViewItem = {
+  id: string;
+  date: string;
+  qty: number;
+  unit_price: number;
+  menu_items?: {
+    name?: string | null;
+    vendors?: {
+      name?: string | null;
+    } | null;
+  } | null;
+  order_item_options: {
+    name: string;
+    price_delta: number;
+  }[];
+};
+
+export function buildCartViewModel(items: CartViewItem[]) {
+  const byDate = items.reduce<Record<string, CartViewItem[]>>((acc, item) => {
+    (acc[item.date] ??= []).push(item);
+    return acc;
+  }, {});
+
+  return {
+    byDate,
+    dates: Object.keys(byDate).sort(),
+    itemCount: items.length,
+    total: items.reduce((sum, item) => sum + item.unit_price * item.qty, 0),
+  };
+}

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,4 +1,5 @@
 import { CartActions } from "@/app/cart/cart-actions";
+import { buildCartViewModel } from "@/app/cart/cart-view";
 import { RemoveButton } from "@/app/cart/remove-button";
 import { Separator } from "@/components/ui/separator";
 import { createClient } from "@/lib/supabase/server";
@@ -29,14 +30,7 @@ export default async function CartPage() {
       ).data ?? []
     : [];
 
-  // 按日期分組
-  const byDate = items.reduce<Record<string, typeof items>>((acc, item) => {
-    (acc[item.date] ??= []).push(item);
-    return acc;
-  }, {});
-
-  const total = items.reduce((sum, i) => sum + i.unit_price * i.qty, 0);
-  const dates = Object.keys(byDate).sort();
+  const { byDate, dates, itemCount, total } = buildCartViewModel(items);
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
@@ -79,10 +73,10 @@ export default async function CartPage() {
           <>
             <Separator />
             <div className="flex justify-between items-center">
-              <p className="text-sm text-muted-foreground">共 {items.length} 項</p>
+              <p className="text-sm text-muted-foreground">共 {itemCount} 項</p>
               <p className="text-lg font-bold">合計 ${total.toFixed(0)}</p>
             </div>
-            <CartActions orderId={order.id} total={total} itemCount={items.length} />
+            <CartActions orderId={order.id} total={total} itemCount={itemCount} />
           </>
         )}
       </div>

--- a/app/orders/actions.test.ts
+++ b/app/orders/actions.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+import { getOrders } from "@/app/orders/actions";
+
+type QueryStep = {
+  orderResult?: unknown;
+  rangeResult?: unknown;
+};
+
+function createQuery(step: QueryStep = {}) {
+  const query: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  query.select = vi.fn(() => query);
+  query.eq = vi.fn(() => query);
+  query.neq = vi.fn(() => query);
+  query.order = vi.fn(() => {
+    if (step.orderResult === undefined) return query;
+    return Promise.resolve(step.orderResult);
+  });
+  query.range = vi.fn(async () => step.rangeResult);
+  query.in = vi.fn(() => query);
+
+  return query;
+}
+
+function createSupabaseMock({
+  user,
+  queries,
+}: {
+  user: { id: string } | null;
+  queries: Record<string, QueryStep[]>;
+}) {
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user },
+      })),
+    },
+    from: vi.fn((table: string) => {
+      const steps = queries[table];
+      if (!steps || steps.length === 0) {
+        throw new Error(`No query step configured for table ${table}`);
+      }
+
+      return createQuery(steps.shift());
+    }),
+  };
+}
+
+describe("getOrders", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+  });
+
+  it("returns an empty result when the user is not logged in", async () => {
+    createClientMock.mockResolvedValue(
+      createSupabaseMock({
+        user: null,
+        queries: {},
+      })
+    );
+
+    await expect(getOrders(0)).resolves.toEqual({
+      orders: [],
+      hasMore: false,
+    });
+  });
+
+  it("returns paginated non-pending orders with normalized items", async () => {
+    createClientMock.mockResolvedValue(
+      createSupabaseMock({
+        user: { id: "user-1" },
+        queries: {
+          orders: [
+            {
+              rangeResult: {
+                data: [
+                  {
+                    id: "order-2",
+                    status: "completed",
+                    created_at: "2026-04-02T10:00:00.000Z",
+                  },
+                  {
+                    id: "order-1",
+                    status: "confirmed",
+                    created_at: "2026-04-01T10:00:00.000Z",
+                  },
+                ],
+              },
+            },
+          ],
+          order_items: [
+            {
+              orderResult: {
+                data: [
+                  {
+                    id: "item-1",
+                    date: "2026-04-01",
+                    qty: 2,
+                    unit_price: 100,
+                    picked_up: false,
+                    order_id: "order-1",
+                    menu_items: {
+                      name: "雞胸便當",
+                      vendors: { name: "健康餐盒" },
+                    },
+                    order_item_options: [{ name: "加蛋", price_delta: 10 }],
+                  },
+                  {
+                    id: "item-2",
+                    date: "2026-04-02",
+                    qty: 1,
+                    unit_price: 80,
+                    picked_up: true,
+                    order_id: "order-2",
+                    menu_items: null,
+                    order_item_options: null,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      })
+    );
+
+    await expect(getOrders(0, 1)).resolves.toEqual({
+      orders: [
+        {
+          id: "order-2",
+          status: "completed",
+          created_at: "2026-04-02T10:00:00.000Z",
+          items: [
+            {
+              id: "item-2",
+              date: "2026-04-02",
+              qty: 1,
+              unit_price: 80,
+              picked_up: true,
+              menu_item_name: "",
+              vendor_name: "",
+              options: [],
+            },
+          ],
+        },
+      ],
+      hasMore: true,
+    });
+  });
+});

--- a/app/orders/actions.ts
+++ b/app/orders/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { buildOrderSummaries } from "@/app/orders/order-summary";
 import { createClient } from "@/lib/supabase/server";
 
 export type OrderSummary = {
@@ -54,30 +55,10 @@ export async function getOrders(
     .in("order_id", orderIds)
     .order("date");
 
-  const itemsByOrder = new Map<string, typeof allItems>();
-  for (const item of allItems ?? []) {
-    const list = itemsByOrder.get(item.order_id) ?? [];
-    list.push(item);
-    itemsByOrder.set(item.order_id, list);
-  }
-
-  const result: OrderSummary[] = pageOrders.map((order) => ({
-    id: order.id,
-    status: order.status,
-    created_at: order.created_at,
-    items: (itemsByOrder.get(order.id) ?? []).map((i) => ({
-      id: i.id,
-      date: i.date,
-      qty: i.qty,
-      unit_price: i.unit_price,
-      picked_up: i.picked_up,
-      menu_item_name: (i.menu_items as { name: string } | null)?.name ?? "",
-      vendor_name:
-        (i.menu_items as { vendors: { name: string } | null } | null)
-          ?.vendors?.name ?? "",
-      options: (i.order_item_options as { name: string; price_delta: number }[]) ?? [],
-    })),
-  }));
+  const result = buildOrderSummaries(
+    pageOrders,
+    (allItems as Parameters<typeof buildOrderSummaries>[1] | null) ?? []
+  );
 
   return { orders: result, hasMore };
 }

--- a/app/orders/order-summary.test.ts
+++ b/app/orders/order-summary.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOrderSummaries } from "@/app/orders/order-summary";
+
+describe("buildOrderSummaries", () => {
+  it("maps items by order and preserves pagination order", () => {
+    const result = buildOrderSummaries(
+      [
+        {
+          id: "order-2",
+          status: "completed",
+          created_at: "2026-04-02T10:00:00.000Z",
+        },
+        {
+          id: "order-1",
+          status: "confirmed",
+          created_at: "2026-04-01T10:00:00.000Z",
+        },
+      ],
+      [
+        {
+          id: "item-1",
+          date: "2026-04-01",
+          qty: 2,
+          unit_price: 100,
+          picked_up: false,
+          order_id: "order-1",
+          menu_items: {
+            name: "雞胸便當",
+            vendors: { name: "健康餐盒" },
+          },
+          order_item_options: [{ name: "加蛋", price_delta: 10 }],
+        },
+        {
+          id: "item-2",
+          date: "2026-04-02",
+          qty: 1,
+          unit_price: 80,
+          picked_up: true,
+          order_id: "order-2",
+          menu_items: {
+            name: "燒肉飯",
+            vendors: { name: "食堂" },
+          },
+          order_item_options: [],
+        },
+      ]
+    );
+
+    expect(result.map((order) => order.id)).toEqual(["order-2", "order-1"]);
+    expect(result[0].items[0]).toMatchObject({
+      id: "item-2",
+      menu_item_name: "燒肉飯",
+      vendor_name: "食堂",
+    });
+    expect(result[1].items[0]).toMatchObject({
+      id: "item-1",
+      options: [{ name: "加蛋", price_delta: 10 }],
+    });
+  });
+
+  it("fills missing nested values with safe defaults", () => {
+    const result = buildOrderSummaries(
+      [
+        {
+          id: "order-1",
+          status: "cancelled",
+          created_at: "2026-04-01T10:00:00.000Z",
+        },
+      ],
+      [
+        {
+          id: "item-1",
+          date: "2026-04-01",
+          qty: 1,
+          unit_price: 100,
+          picked_up: false,
+          order_id: "order-1",
+          menu_items: null,
+          order_item_options: null,
+        },
+      ]
+    );
+
+    expect(result[0].items[0]).toMatchObject({
+      menu_item_name: "",
+      vendor_name: "",
+      options: [],
+    });
+  });
+});

--- a/app/orders/order-summary.ts
+++ b/app/orders/order-summary.ts
@@ -1,0 +1,50 @@
+import type { OrderSummary } from "@/app/orders/actions";
+
+type OrderRow = {
+  id: string;
+  status: string;
+  created_at: string;
+};
+
+type OrderItemRow = {
+  id: string;
+  date: string;
+  qty: number;
+  unit_price: number;
+  picked_up: boolean;
+  order_id: string;
+  menu_items: {
+    name: string;
+    vendors: { name: string } | null;
+  } | null;
+  order_item_options: { name: string; price_delta: number }[] | null;
+};
+
+export function buildOrderSummaries(
+  orders: OrderRow[],
+  allItems: OrderItemRow[]
+): OrderSummary[] {
+  const itemsByOrder = new Map<string, OrderItemRow[]>();
+
+  for (const item of allItems) {
+    const list = itemsByOrder.get(item.order_id) ?? [];
+    list.push(item);
+    itemsByOrder.set(item.order_id, list);
+  }
+
+  return orders.map((order) => ({
+    id: order.id,
+    status: order.status,
+    created_at: order.created_at,
+    items: (itemsByOrder.get(order.id) ?? []).map((item) => ({
+      id: item.id,
+      date: item.date,
+      qty: item.qty,
+      unit_price: item.unit_price,
+      picked_up: item.picked_up,
+      menu_item_name: item.menu_items?.name ?? "",
+      vendor_name: item.menu_items?.vendors?.name ?? "",
+      options: item.order_item_options ?? [],
+    })),
+  }));
+}

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "eslint-config-next": "16.2.1",
         "tailwindcss": "^4",
         "typescript": "^5",
+        "vitest": "^4.1.2",
       },
     },
   },
@@ -260,6 +261,8 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
@@ -382,11 +385,45 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm" }, "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.12", "", { "os": "none", "cpu": "arm64" }, "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.12", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "x64" }, "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
+
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.99.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-vMEVLA1kGGYd/kdsJSwtjiFUZM1nGfrz2DWmgMBZtocV48qL+L2+4QpIkueXyBEumMQZFEyhz57i/5zGHjvdBw=="],
 
@@ -437,6 +474,10 @@
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -518,6 +559,20 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.2", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.2", "", { "dependencies": { "@vitest/utils": "4.1.2", "pathe": "^2.0.3" } }, "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.2", "", {}, "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -555,6 +610,8 @@
     "array.prototype.tosorted": ["array.prototype.tosorted@1.1.4", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3", "es-errors": "^1.3.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA=="],
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
@@ -595,6 +652,8 @@
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001780", "", {}, "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -714,6 +773,8 @@
 
     "es-iterator-helpers": ["es-iterator-helpers@1.3.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.1", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0", "safe-array-concat": "^1.1.3" } }, "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ=="],
 
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
@@ -760,6 +821,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -769,6 +832,8 @@
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -1136,6 +1201,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -1175,6 +1242,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1256,6 +1325,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -1304,6 +1375,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -1314,7 +1387,11 @@
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -1362,7 +1439,13 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tldts": ["tldts@7.0.27", "", { "dependencies": { "tldts-core": "^7.0.27" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg=="],
 
@@ -1432,6 +1515,10 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
+
+    "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1445,6 +1532,8 @@
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1491,6 +1580,8 @@
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -1563,6 +1654,10 @@
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test": "vitest run && playwright test",
+    "test:e2e": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
@@ -37,7 +39,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.2"
   },
   "ignoreScripts": [
     "sharp",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.ts"],
+    exclude: ["e2e/**", "node_modules/**", ".next/**"],
+    clearMocks: true,
+    restoreMocks: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
+});


### PR DESCRIPTION
• ## Summary

  - Add a layered testing setup with Vitest for unit tests and mocked integration tests, while keeping existing Playwright E2E coverage
  - Extract cart and order data-shaping logic into small testable helpers without changing behavior
  - Document the new test commands and current test coverage in [README.md](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/README.md)

## Changes

  - Updated [package.json](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/package.json) scripts:
      - test: runs Vitest first, then Playwright
      - test:unit: runs unit tests and mocked integration tests
      - test:e2e: runs Playwright only
      - test:ui: Playwright UI mode
  - Added [vitest.config.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/vitest.config.ts) with @/ alias support
  - Added [app/cart/cart-view.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/cart/cart-view.ts) and [app/orders/order-summary.ts](/Users/grantyeh/Grant/Project/CN_Project/
    nycueats.winlab.tw/app/orders/order-summary.ts) to isolate pure logic
  - Updated [app/cart/page.tsx](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/cart/page.tsx) and [app/orders/actions.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/
    orders/actions.ts) to use the extracted helpers
  - Fixed the extracted CartViewItem type so cart page usage of menu_items and order_item_options remains type-safe
  - Added tests:
      - [app/cart/cart-view.test.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/cart/cart-view.test.ts)
      - [app/orders/order-summary.test.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/orders/order-summary.test.ts)
      - [app/cart/actions.test.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/cart/actions.test.ts)
      - [app/orders/actions.test.ts](/Users/grantyeh/Grant/Project/CN_Project/nycueats.winlab.tw/app/orders/actions.test.ts)
