### PR TITLE
feat(admin): 月結報表 CSV 匯出 + 使用者角色管理

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -29,6 +29,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <Link href="/admin/reports">
             <Button variant="outline" size="sm">月結報表</Button>
           </Link>
+          <Link href="/admin/users">
+            <Button variant="outline" size="sm">使用者管理</Button>
+          </Link>
         </nav>
         {children}
       </div>

--- a/app/admin/users/actions.ts
+++ b/app/admin/users/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { requireRole } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+
+export async function grantVendorRole(targetUserId: string) {
+  const { supabase } = await requireRole("admin");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", targetUserId)
+    .single();
+
+  if (!profile) return { error: "找不到使用者" };
+
+  if (profile.role.includes("vendor")) return { success: true };
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ role: [...profile.role, "vendor"] })
+    .eq("id", targetUserId);
+
+  if (error) return { error: "授權失敗" };
+  revalidatePath("/admin/users");
+  return { success: true };
+}
+
+export async function revokeVendorRole(targetUserId: string) {
+  const { supabase } = await requireRole("admin");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", targetUserId)
+    .single();
+
+  if (!profile) return { error: "找不到使用者" };
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ role: profile.role.filter((r) => r !== "vendor") })
+    .eq("id", targetUserId);
+
+  if (error) return { error: "撤銷失敗" };
+  revalidatePath("/admin/users");
+  return { success: true };
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,48 @@
+import { requireRole } from "@/lib/auth";
+import { UserRoleRow } from "./user-role-row";
+
+export default async function AdminUsersPage() {
+  const { supabase, user } = await requireRole("admin");
+
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select("id, name, email, role")
+    .order("created_at", { ascending: false });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">使用者管理</h1>
+        <p className="text-sm text-muted-foreground">{profiles?.length ?? 0} 位使用者</p>
+      </div>
+
+      {!profiles || profiles.length === 0 ? (
+        <p className="text-muted-foreground text-center py-8">尚無使用者</p>
+      ) : (
+        <div className="border rounded-lg overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b bg-muted/30">
+                <th className="text-left p-3 text-sm font-medium">使用者</th>
+                <th className="text-left p-3 text-sm font-medium">角色</th>
+                <th className="text-right p-3 text-sm font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {profiles.map((profile) => (
+                <UserRoleRow
+                  key={profile.id}
+                  userId={profile.id}
+                  name={profile.name}
+                  email={profile.email}
+                  roles={profile.role}
+                  isSelf={profile.id === user.id}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/users/user-role-row.tsx
+++ b/app/admin/users/user-role-row.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTransition } from "react";
+import { grantVendorRole, revokeVendorRole } from "./actions";
+
+interface Props {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  roles: string[];
+  isSelf: boolean;
+}
+
+export function UserRoleRow({ userId, name, email, roles, isSelf }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const isVendor = roles.includes("vendor");
+  const isAdmin = roles.includes("admin");
+
+  const toggle = () => {
+    startTransition(async () => {
+      if (isVendor) {
+        await revokeVendorRole(userId);
+      } else {
+        await grantVendorRole(userId);
+      }
+    });
+  };
+
+  return (
+    <tr className="border-b last:border-b-0">
+      <td className="p-3 text-sm">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-medium">{name ?? "（未設定）"}</span>
+          <span className="text-xs text-muted-foreground">{email}</span>
+        </div>
+      </td>
+      <td className="p-3">
+        <div className="flex flex-wrap gap-1">
+          <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">user</span>
+          {isVendor && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600">vendor</span>
+          )}
+          {isAdmin && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-purple-50 text-purple-600">admin</span>
+          )}
+        </div>
+      </td>
+      <td className="p-3 text-right">
+        <button
+          onClick={toggle}
+          disabled={isPending || isSelf}
+          className={`text-xs px-3 py-1 rounded-full border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+            isVendor
+              ? "border-destructive text-destructive hover:bg-destructive/5"
+              : "border-blue-500 text-blue-600 hover:bg-blue-50"
+          }`}
+        >
+          {isPending ? "處理中..." : isVendor ? "撤銷 vendor" : "授予 vendor"}
+        </button>
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
## Summary
- Admin A（月結報表 CSV 匯出）：確認已由先前 PR 實作完成，`report-table.tsx` 已有 `exportCSV()` 含 BOM 前綴與欄位對應
- Admin B（使用者角色管理）：新增 `/admin/users` 頁面，admin 可對任一使用者授予或撤銷 `vendor` 角色
  - `app/admin/users/page.tsx` — Server Component，列出所有 profiles
  - `app/admin/users/user-role-row.tsx` — Client Component，`useTransition` 即時更新
  - `app/admin/users/actions.ts` — Server Actions：`grantVendorRole` / `revokeVendorRole`
  - `app/admin/layout.tsx` — nav 加入「使用者管理」連結

## Test plan
- [ ] 以 admin 帳號登入，進入 /admin/users 確認使用者列表顯示正確
- [ ] 對非自身帳號點擊「授予 vendor」→ 角色標籤即時出現 vendor badge
- [ ] 再點「撤銷 vendor」→ badge 消失，頁面刷新後確認持久化
- [ ] 確認自身帳號按鈕為 disabled（不可修改自己）
- [ ] 進入 /admin/reports 確認 CSV 匯出按鈕正常下載

Closes #63
Closes #64