### PR TITLE
fix(vendor): 新增餐點按鈕接上 Dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ next-env.d.ts
 /blob-report/
 /playwright/.cache/
 /e2e/.auth/
+.playwright-mcp/

--- a/app/vendor/menu/add-menu-item-button.tsx
+++ b/app/vendor/menu/add-menu-item-button.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useState, useTransition } from "react";
+import { upsertMenuItem } from "./actions";
+
+export function AddMenuItemButton() {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const toNum = (key: string) => {
+      const v = parseFloat(fd.get(key) as string);
+      return isNaN(v) ? undefined : v;
+    };
+    startTransition(async () => {
+      const result = await upsertMenuItem({
+        name: fd.get("name") as string,
+        description: (fd.get("description") as string) || undefined,
+        price: toNum("price") ?? 0,
+        default_max_qty: toNum("default_max_qty"),
+      });
+      if (result?.error) {
+        alert(result.error);
+      } else {
+        setOpen(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        新增餐點
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>新增餐點</DialogTitle>
+          </DialogHeader>
+          <form id="add-item-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="add-name">名稱</Label>
+              <Input id="add-name" name="name" required placeholder="餐點名稱" />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="add-description">描述</Label>
+              <Input id="add-description" name="description" placeholder="選填" />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="add-price">價格</Label>
+                <Input
+                  id="add-price"
+                  name="price"
+                  type="number"
+                  min={0}
+                  step={1}
+                  required
+                  placeholder="0"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="add-default_max_qty">每日供應量</Label>
+                <Input
+                  id="add-default_max_qty"
+                  name="default_max_qty"
+                  type="number"
+                  min={0}
+                  step={1}
+                  placeholder="0"
+                />
+              </div>
+            </div>
+          </form>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => setOpen(false)}
+            >
+              取消
+            </Button>
+            <Button type="submit" form="add-item-form" disabled={isPending}>
+              {isPending ? "新增中…" : "新增"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { AddMenuItemButton } from "./add-menu-item-button";
 import { VendorMenuItemCard } from "./menu-item-card";
 
 export default async function VendorMenuPage() {
@@ -38,7 +38,7 @@ export default async function VendorMenuPage() {
     <div className="flex flex-col gap-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">{vendor.name} — 菜單管理</h1>
-        <Button size="sm">新增餐點</Button>
+        <AddMenuItemButton />
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {itemsWithSlots.map((item) => (


### PR DESCRIPTION
## Summary

- `新增餐點` 按鈕原為沒有 `onClick` 的 Server Component 裸 Button，點擊無反應
- 新增 `AddMenuItemButton` client component，內含 Dialog + 新增表單
- 表單呼叫既有 `upsertMenuItem`（不帶 id 走 INSERT 路徑）

## Test plan

- [ ] 以 vendor 角色登入，進入 `/vendor/menu`
- [ ] 點擊「新增餐點」按鈕確認 Dialog 彈出
- [ ] 填寫名稱、價格，點擊「新增」，確認餐點出現在列表中
- [ ] 點擊「取消」確認 Dialog 關閉

Closes #69