### PR TITLE
feat(vendor): bulk slot creation with expiry banner

### DIFF
--- a/app/vendor/menu/actions.ts
+++ b/app/vendor/menu/actions.ts
@@ -145,3 +145,39 @@ export async function deleteMenuItem(id: string) {
   return { success: true };
 }
 
+export async function bulkUpsertSlots(
+  slots: { menu_item_id: string; date: string; max_qty: number }[]
+) {
+  const { supabase, vendor } = await requireVendor();
+
+  // Verify all menu items belong to this vendor
+  const itemIds = [...new Set(slots.map((s) => s.menu_item_id))];
+  const { data: ownedItems } = await supabase
+    .from("menu_items")
+    .select("id")
+    .eq("vendor_id", vendor.id)
+    .in("id", itemIds);
+
+  const ownedIds = new Set((ownedItems ?? []).map((i) => i.id));
+  const validSlots = slots.filter((s) => ownedIds.has(s.menu_item_id));
+
+  if (validSlots.length === 0) return { error: "沒有可建立的名額" };
+
+  const { error } = await supabase
+    .from("daily_slots")
+    .upsert(
+      validSlots.map((s) => ({
+        menu_item_id: s.menu_item_id,
+        date: s.date,
+        max_qty: s.max_qty,
+      })),
+      { onConflict: "menu_item_id,date" }
+    );
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/vendor/menu");
+  revalidatePath("/menu", "layout");
+  return { success: true, count: validSlots.length };
+}
+

--- a/app/vendor/menu/bulk-slot-confirm-dialog.tsx
+++ b/app/vendor/menu/bulk-slot-confirm-dialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+export interface UntouchedItem {
+  name: string;
+  defaultMaxQty: number;
+  untouchedCount: number;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: UntouchedItem[];
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+export function BulkSlotConfirmDialog({
+  open,
+  onOpenChange,
+  items,
+  onConfirm,
+  isPending,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>確認建立名額</DialogTitle>
+          <DialogDescription>
+            以下餐點尚有未設定的日期，儲存時將使用各餐點的預設供應量：
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="flex flex-col gap-1.5 text-sm">
+          {items.map((item) => (
+            <li key={item.name} className="flex justify-between">
+              <span>{item.name}</span>
+              <span className="text-muted-foreground">
+                {item.defaultMaxQty} 份/天（{item.untouchedCount} 天未設定）
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            取消
+          </Button>
+          <Button onClick={onConfirm} disabled={isPending}>
+            {isPending ? "建立中…" : "確認建立"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/vendor/menu/bulk-slot-dialog.tsx
+++ b/app/vendor/menu/bulk-slot-dialog.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { startOfWeek, addDays, format } from "date-fns";
+import { useState, useTransition } from "react";
+import { bulkUpsertSlots } from "./actions";
+import { BulkSlotConfirmDialog, type UntouchedItem } from "./bulk-slot-confirm-dialog";
+import { Sparkline } from "./sparkline";
+
+type Slot = { id: string; date: string; max_qty: number; reserved_qty: number };
+
+export type BulkSlotItem = {
+  id: string;
+  name: string;
+  default_max_qty: number;
+  daily_slots: Slot[];
+};
+
+export type SalesDataMap = Record<
+  string,
+  { dailySales: number[]; avgPerDay: number; daysWithData: number }
+>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: BulkSlotItem[];
+  operatingDays: number[];
+  salesData: SalesDataMap;
+  onSuccess: (message: string) => void;
+}
+
+const DAY_LABELS = ["日", "一", "二", "三", "四", "五", "六"];
+
+function generateDates(): string[] {
+  const today = new Date();
+  const sunday = startOfWeek(today, { weekStartsOn: 0 });
+  return Array.from({ length: 14 }, (_, i) =>
+    addDays(sunday, i).toISOString().split("T")[0]
+  );
+}
+
+type CellState = "existing" | "untouched" | "touched" | "disabled";
+
+function getCellState(
+  date: string,
+  today: string,
+  operatingDays: number[],
+  slotMap: Map<string, Slot>,
+  touchedSet: Set<string>,
+): CellState {
+  const dayOfWeek = new Date(date + "T00:00:00").getDay();
+  if (date <= today) return "disabled";
+  if (operatingDays.length > 0 && !operatingDays.includes(dayOfWeek)) return "disabled";
+  if (slotMap.has(date)) return touchedSet.has(date) ? "touched" : "existing";
+  return touchedSet.has(date) ? "touched" : "untouched";
+}
+
+export function BulkSlotDialog({
+  open,
+  onOpenChange,
+  items,
+  operatingDays,
+  salesData,
+  onSuccess,
+}: Props) {
+  const dates = generateDates();
+  const today = new Date().toISOString().split("T")[0];
+  const [isPending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const [overrides, setOverrides] = useState<Record<string, Record<string, number>>>({});
+  const [touched, setTouched] = useState<Record<string, Set<string>>>({});
+
+  function getQty(itemId: string, date: string, slotMap: Map<string, Slot>, defaultQty: number): number {
+    return overrides[itemId]?.[date] ?? slotMap.get(date)?.max_qty ?? defaultQty;
+  }
+
+  function handleQtyChange(itemId: string, date: string, value: string, defaultQty: number) {
+    const qty = parseInt(value);
+    if (isNaN(qty) || qty < 0) return;
+    setOverrides((prev) => ({
+      ...prev,
+      [itemId]: { ...prev[itemId], [date]: qty },
+    }));
+    setTouched((prev) => {
+      const next = new Map(Object.entries(prev).map(([k, v]) => [k, new Set(v)]));
+      const set = next.get(itemId) ?? new Set<string>();
+      set.add(date);
+      next.set(itemId, set);
+      return Object.fromEntries(next);
+    });
+  }
+
+  function collectSlots(): { menu_item_id: string; date: string; max_qty: number }[] {
+    const slots: { menu_item_id: string; date: string; max_qty: number }[] = [];
+    for (const item of items) {
+      const slotMap = new Map(item.daily_slots.map((s) => [s.date, s]));
+      for (const date of dates) {
+        const state = getCellState(date, today, operatingDays, slotMap, touched[item.id] ?? new Set());
+        if (state === "disabled") continue;
+        const qty = getQty(item.id, date, slotMap, item.default_max_qty);
+        slots.push({ menu_item_id: item.id, date, max_qty: qty });
+      }
+    }
+    return slots;
+  }
+
+  function getUntouchedItems(): UntouchedItem[] {
+    const result: UntouchedItem[] = [];
+    for (const item of items) {
+      const slotMap = new Map(item.daily_slots.map((s) => [s.date, s]));
+      let count = 0;
+      for (const date of dates) {
+        const state = getCellState(date, today, operatingDays, slotMap, touched[item.id] ?? new Set());
+        if (state === "untouched") count++;
+      }
+      if (count > 0) {
+        result.push({ name: item.name, defaultMaxQty: item.default_max_qty, untouchedCount: count });
+      }
+    }
+    return result;
+  }
+
+  function handleSave() {
+    const untouched = getUntouchedItems();
+    if (untouched.length > 0) {
+      setConfirmOpen(true);
+      return;
+    }
+    doSave();
+  }
+
+  function doSave() {
+    const slots = collectSlots();
+    startTransition(async () => {
+      const result = await bulkUpsertSlots(slots);
+      setConfirmOpen(false);
+      if (result.error) {
+        alert(result.error);
+      } else {
+        const firstFuture = dates.find((d) => d > today) ?? dates[0];
+        const dateRange = `${format(new Date(firstFuture + "T00:00:00"), "M/d")}–${format(new Date(dates[dates.length - 1] + "T00:00:00"), "M/d")}`;
+        onSuccess(`已成功建立 ${dateRange} 的名額（共 ${result.count} 筆）`);
+        onOpenChange(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-6xl max-h-[90dvh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>建立未來名額</DialogTitle>
+            <DialogDescription>
+              ℹ️ 黯淡的格子表示尚未設定名額，儲存時將使用預設供應量。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-6">
+            {items.map((item) => {
+              const slotMap = new Map(item.daily_slots.map((s) => [s.date, s]));
+              const sales = salesData[item.id];
+              const touchedSet = touched[item.id] ?? new Set<string>();
+
+              return (
+                <div key={item.id} className="border rounded-lg p-4 flex flex-col gap-3">
+                  <div className="flex items-center gap-3">
+                    <span className="font-medium">{item.name}</span>
+                    {sales && sales.daysWithData > 0 ? (
+                      <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Sparkline data={sales.dailySales} className="text-foreground" />
+                        近 {sales.daysWithData} 天平均 {sales.avgPerDay.toFixed(1)} 份/天
+                      </span>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">尚無銷售資料</span>
+                    )}
+                  </div>
+
+                  {[0, 7].map((offset) => (
+                    <div key={offset} className="grid grid-cols-7 gap-2">
+                      {dates.slice(offset, offset + 7).map((date) => {
+                        const state = getCellState(date, today, operatingDays, slotMap, touchedSet);
+                        const slot = slotMap.get(date);
+                        const dayOfWeek = new Date(date + "T00:00:00").getDay();
+                        const isDisabled = state === "disabled";
+                        const isUntouched = state === "untouched";
+                        const displayQty = getQty(item.id, date, slotMap, item.default_max_qty);
+
+                        return (
+                          <div key={date} className="flex flex-col gap-1 items-center">
+                            <p className="text-xs text-muted-foreground">
+                              {DAY_LABELS[dayOfWeek]} {format(new Date(date + "T00:00:00"), "M/d")}
+                            </p>
+                            <Input
+                              type="number"
+                              min={0}
+                              value={displayQty}
+                              disabled={isDisabled}
+                              className={`w-full text-center px-1 ${
+                                isDisabled
+                                  ? "bg-muted text-muted-foreground opacity-50"
+                                  : isUntouched
+                                    ? "text-muted-foreground border-dashed"
+                                    : ""
+                              }`}
+                              onChange={(e) =>
+                                handleQtyChange(item.id, date, e.target.value, item.default_max_qty)
+                              }
+                            />
+                            {slot && slot.reserved_qty > 0 && (
+                              <p className="text-xs text-muted-foreground">已訂 {slot.reserved_qty}</p>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              取消
+            </Button>
+            <Button onClick={handleSave} disabled={isPending}>
+              {isPending ? "儲存中…" : "儲存名額"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <BulkSlotConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        items={getUntouchedItems()}
+        onConfirm={doSave}
+        isPending={isPending}
+      />
+    </>
+  );
+}

--- a/app/vendor/menu/bulk-slot-dialog.tsx
+++ b/app/vendor/menu/bulk-slot-dialog.tsx
@@ -81,11 +81,11 @@ export function BulkSlotDialog({
   const [overrides, setOverrides] = useState<Record<string, Record<string, number>>>({});
   const [touched, setTouched] = useState<Record<string, Set<string>>>({});
 
-  function getQty(itemId: string, date: string, slotMap: Map<string, Slot>, defaultQty: number): number {
-    return overrides[itemId]?.[date] ?? slotMap.get(date)?.max_qty ?? defaultQty;
+  function getQty(itemId: string, date: string, slotMap: Map<string, Slot>, fallbackQty: number): number {
+    return overrides[itemId]?.[date] ?? slotMap.get(date)?.max_qty ?? fallbackQty;
   }
 
-  function handleQtyChange(itemId: string, date: string, value: string, defaultQty: number) {
+  function handleQtyChange(itemId: string, date: string, value: string) {
     const qty = parseInt(value);
     if (isNaN(qty) || qty < 0) return;
     setOverrides((prev) => ({
@@ -215,7 +215,7 @@ export function BulkSlotDialog({
                                     : ""
                               }`}
                               onChange={(e) =>
-                                handleQtyChange(item.id, date, e.target.value, item.default_max_qty)
+                                handleQtyChange(item.id, date, e.target.value)
                               }
                             />
                             {slot && slot.reserved_qty > 0 && (

--- a/app/vendor/menu/menu-item-card.tsx
+++ b/app/vendor/menu/menu-item-card.tsx
@@ -24,8 +24,24 @@ type Item = {
   }[];
 };
 
-export function VendorMenuItemCard({ item }: { item: Item }) {
+export type SlotStatus = "expiring" | "none" | "ok";
+
+export function VendorMenuItemCard({ item, slotStatus }: { item: Item; slotStatus: SlotStatus }) {
   const [editOpen, setEditOpen] = useState(false);
+
+  const badge = (
+    <div className="flex flex-wrap gap-1.5">
+      {!item.is_available && (
+        <span className="text-xs text-muted-foreground border rounded-full px-2 py-0.5">已下架</span>
+      )}
+      {slotStatus === "none" && (
+        <span className="text-xs text-red-600 border border-red-200 bg-red-50 rounded-full px-2 py-0.5 dark:text-red-400 dark:border-red-900 dark:bg-red-950">無名額</span>
+      )}
+      {slotStatus === "expiring" && (
+        <span className="text-xs text-amber-600 border border-amber-200 bg-amber-50 rounded-full px-2 py-0.5 dark:text-amber-400 dark:border-amber-900 dark:bg-amber-950">名額將盡</span>
+      )}
+    </div>
+  );
 
   return (
     <>
@@ -33,11 +49,7 @@ export function VendorMenuItemCard({ item }: { item: Item }) {
       <MenuItemCard
         item={item}
         onClick={() => setEditOpen(true)}
-        status={
-          !item.is_available && (
-            <span className="text-xs text-muted-foreground border rounded-full px-2 py-0.5 self-start">已下架</span>
-          )
-        }
+        status={badge}
       />
     </>
   );

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -1,7 +1,24 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { AddMenuItemButton } from "./add-menu-item-button";
-import { VendorMenuItemCard } from "./menu-item-card";
+import { VendorMenuItemCard, type SlotStatus } from "./menu-item-card";
+
+function getSlotStatus(slots: { max_qty: number; reserved_qty: number }[]): SlotStatus {
+  if (slots.length === 0) {
+    return "none";
+  }
+  const totalSlots = slots.reduce((sum, s) => sum + s.max_qty, 0);
+  const totalReserved = slots.reduce((sum, s) => sum + s.reserved_qty, 0);
+  const remaining = totalSlots - totalReserved;
+
+  if (remaining === 0) {
+    return "none";
+  }
+  if (remaining <= Math.ceil(totalSlots * 0.2)) {
+    return "expiring";
+  }
+  return "ok";
+}
 
 export default async function VendorMenuPage() {
   const supabase = await createClient();
@@ -42,7 +59,11 @@ export default async function VendorMenuPage() {
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {itemsWithSlots.map((item) => (
-          <VendorMenuItemCard key={item.id} item={item} />
+          <VendorMenuItemCard
+            key={item.id}
+            item={item}
+            slotStatus={getSlotStatus(item.daily_slots)}
+          />
         ))}
         {itemsWithSlots.length === 0 && (
           <p className="text-muted-foreground text-center py-8">尚無餐點，請新增</p>

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -42,10 +42,10 @@ export default async function VendorMenuPage() {
 
   // Compute slot status per item
   const slotStatuses = new Map<string, SlotStatus>();
-  const availableItems = allItems.filter((i) => i.is_available);
   let expiringCount = 0;
 
   for (const item of allItems) {
+    // Unavailable items can't be ordered; skip slot-expiry check
     if (!item.is_available) {
       slotStatuses.set(item.id, "ok");
       continue;
@@ -76,12 +76,14 @@ export default async function VendorMenuPage() {
   }));
 
   // Prepare data for bulk dialog (all slots, only available items)
-  const bulkDialogItems: BulkSlotItem[] = availableItems.map((item) => ({
-    id: item.id,
-    name: item.name,
-    default_max_qty: item.default_max_qty,
-    daily_slots: item.daily_slots ?? [],
-  }));
+  const bulkDialogItems: BulkSlotItem[] = allItems
+    .filter((i) => i.is_available)
+    .map((item) => ({
+      id: item.id,
+      name: item.name,
+      default_max_qty: item.default_max_qty,
+      daily_slots: item.daily_slots ?? [],
+    }));
 
   return (
     <div className="flex flex-col gap-4">
@@ -129,7 +131,7 @@ async function fetchSalesData(
 
   const validStatuses = new Set(["confirmed", "completed", "picked_up"]);
   const filtered = (salesRaw ?? []).filter(
-    (r) => validStatuses.has((r.orders as unknown as { status: string }).status)
+    (r) => r.orders && validStatuses.has(r.orders.status)
   );
 
   // Group by menu_item_id → date → total qty

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -1,24 +1,7 @@
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { AddMenuItemButton } from "./add-menu-item-button";
-import { VendorMenuItemCard, type SlotStatus } from "./menu-item-card";
-
-function getSlotStatus(slots: { max_qty: number; reserved_qty: number }[]): SlotStatus {
-  if (slots.length === 0) {
-    return "none";
-  }
-  const totalSlots = slots.reduce((sum, s) => sum + s.max_qty, 0);
-  const totalReserved = slots.reduce((sum, s) => sum + s.reserved_qty, 0);
-  const remaining = totalSlots - totalReserved;
-
-  if (remaining === 0) {
-    return "none";
-  }
-  if (remaining <= Math.ceil(totalSlots * 0.2)) {
-    return "expiring";
-  }
-  return "ok";
-}
+import { VendorMenuItemCard } from "./menu-item-card";
 
 export default async function VendorMenuPage() {
   const supabase = await createClient();
@@ -55,15 +38,11 @@ export default async function VendorMenuPage() {
     <div className="flex flex-col gap-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">{vendor.name} — 菜單管理</h1>
-        <AddMenuItemButton />
+        <Button size="sm">新增餐點</Button>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {itemsWithSlots.map((item) => (
-          <VendorMenuItemCard
-            key={item.id}
-            item={item}
-            slotStatus={getSlotStatus(item.daily_slots)}
-          />
+          <VendorMenuItemCard key={item.id} item={item} />
         ))}
         {itemsWithSlots.length === 0 && (
           <p className="text-muted-foreground text-center py-8">尚無餐點，請新增</p>

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -7,6 +7,10 @@ import type { BulkSlotItem, SalesDataMap } from "./bulk-slot-dialog";
 
 const EXPIRY_THRESHOLD_DAYS = 10;
 
+function formatIsoDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
 export default async function VendorMenuPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -22,9 +26,15 @@ export default async function VendorMenuPage() {
     return <p className="text-muted-foreground">尚未綁定商家帳號，請聯絡管理員。</p>;
   }
 
-  const today = new Date().toISOString().split("T")[0];
-  const sevenDaysLater = new Date(Date.now() + 7 * 86400000).toISOString().split("T")[0];
-  const thresholdDate = new Date(Date.now() + EXPIRY_THRESHOLD_DAYS * 86400000).toISOString().split("T")[0];
+  const now = new Date();
+  const today = formatIsoDate(now);
+  const sevenDaysLaterDate = new Date(now);
+  sevenDaysLaterDate.setUTCDate(sevenDaysLaterDate.getUTCDate() + 7);
+  const sevenDaysLater = formatIsoDate(sevenDaysLaterDate);
+
+  const thresholdDateObj = new Date(now);
+  thresholdDateObj.setUTCDate(thresholdDateObj.getUTCDate() + EXPIRY_THRESHOLD_DAYS);
+  const thresholdDate = formatIsoDate(thresholdDateObj);
 
   // Fetch all items with their slots (Supabase fetches all embedded rows)
   const { data: items } = await supabase
@@ -36,9 +46,11 @@ export default async function VendorMenuPage() {
   const allItems = items ?? [];
 
   // Fetch 7-day sales data
-  const sevenDaysAgo = new Date(Date.now() - 7 * 86400000).toISOString().split("T")[0];
+  const sevenDaysAgoDate = new Date(now);
+  sevenDaysAgoDate.setUTCDate(sevenDaysAgoDate.getUTCDate() - 7);
+  const sevenDaysAgo = formatIsoDate(sevenDaysAgoDate);
   const itemIds = allItems.map((i) => i.id);
-  const salesData = await fetchSalesData(supabase, itemIds, sevenDaysAgo);
+  const salesData = await fetchSalesData(supabase, itemIds, sevenDaysAgo, today);
 
   // Compute slot status per item
   const slotStatuses = new Map<string, SlotStatus>();
@@ -120,6 +132,7 @@ async function fetchSalesData(
   supabase: Awaited<ReturnType<typeof createClient>>,
   itemIds: string[],
   sinceDate: string,
+  today: string,
 ): Promise<SalesDataMap> {
   if (itemIds.length === 0) return {};
 
@@ -145,8 +158,11 @@ async function fetchSalesData(
   // Build SalesDataMap: 7 data points (one per day), fill missing days with 0
   const result: SalesDataMap = {};
   const days: string[] = [];
+  const todayDate = new Date(`${today}T00:00:00.000Z`);
   for (let i = 6; i >= 0; i--) {
-    days.push(new Date(Date.now() - i * 86400000).toISOString().split("T")[0]);
+    const day = new Date(todayDate);
+    day.setUTCDate(day.getUTCDate() - i);
+    days.push(formatIsoDate(day));
   }
 
   for (const itemId of itemIds) {

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -1,7 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { VendorMenuItemCard } from "./menu-item-card";
+import { VendorMenuItemCard, type SlotStatus } from "./menu-item-card";
+import { SlotBanner } from "./slot-banner";
+import type { BulkSlotItem, SalesDataMap } from "./bulk-slot-dialog";
+
+const EXPIRY_THRESHOLD_DAYS = 10;
 
 export default async function VendorMenuPage() {
   const supabase = await createClient();
@@ -10,7 +14,7 @@ export default async function VendorMenuPage() {
 
   const { data: vendor } = await supabase
     .from("vendors")
-    .select("id, name")
+    .select("id, name, operating_days")
     .eq("owner_id", user.id)
     .single();
 
@@ -19,19 +23,64 @@ export default async function VendorMenuPage() {
   }
 
   const today = new Date().toISOString().split("T")[0];
-  const sevenDaysLater = new Date(new Date().getTime() + 7 * 86400000).toISOString().split("T")[0];
+  const sevenDaysLater = new Date(Date.now() + 7 * 86400000).toISOString().split("T")[0];
+  const thresholdDate = new Date(Date.now() + EXPIRY_THRESHOLD_DAYS * 86400000).toISOString().split("T")[0];
 
+  // Fetch all items with their slots (Supabase fetches all embedded rows)
   const { data: items } = await supabase
     .from("menu_items")
     .select("id, name, description, price, is_available, default_max_qty, image_url, calories, protein, sodium, sugar, tags, daily_slots(id, date, max_qty, reserved_qty), item_option_groups(id, name, required, max_select, sort_order, item_options(id, name, price_delta, sort_order))")
     .eq("vendor_id", vendor.id)
     .order("name");
 
-  const itemsWithSlots = (items ?? []).map((item) => ({
+  const allItems = items ?? [];
+
+  // Fetch 7-day sales data
+  const sevenDaysAgo = new Date(Date.now() - 7 * 86400000).toISOString().split("T")[0];
+  const itemIds = allItems.map((i) => i.id);
+  const salesData = await fetchSalesData(supabase, itemIds, sevenDaysAgo);
+
+  // Compute slot status per item
+  const slotStatuses = new Map<string, SlotStatus>();
+  const availableItems = allItems.filter((i) => i.is_available);
+  let expiringCount = 0;
+
+  for (const item of allItems) {
+    if (!item.is_available) {
+      slotStatuses.set(item.id, "ok");
+      continue;
+    }
+    const futureSlots = (item.daily_slots ?? []).filter((s) => s.date > today);
+    if (futureSlots.length === 0) {
+      slotStatuses.set(item.id, "none");
+      expiringCount++;
+      continue;
+    }
+    const farthest = futureSlots.reduce((a, b) => (a.date > b.date ? a : b));
+    if (farthest.date <= thresholdDate) {
+      slotStatuses.set(item.id, "expiring");
+      expiringCount++;
+    } else {
+      slotStatuses.set(item.id, "ok");
+    }
+  }
+
+  const showBanner = expiringCount > 0;
+
+  // Prepare data for card display (7-day filtered slots)
+  const itemsForCards = allItems.map((item) => ({
     ...item,
     daily_slots: (item.daily_slots ?? []).filter(
       (s) => s.date > today && s.date <= sevenDaysLater
     ),
+  }));
+
+  // Prepare data for bulk dialog (all slots, only available items)
+  const bulkDialogItems: BulkSlotItem[] = availableItems.map((item) => ({
+    id: item.id,
+    name: item.name,
+    default_max_qty: item.default_max_qty,
+    daily_slots: item.daily_slots ?? [],
   }));
 
   return (
@@ -40,14 +89,76 @@ export default async function VendorMenuPage() {
         <h1 className="text-2xl font-bold">{vendor.name} — 菜單管理</h1>
         <Button size="sm">新增餐點</Button>
       </div>
+
+      <SlotBanner
+        show={showBanner}
+        expiringCount={expiringCount}
+        items={bulkDialogItems}
+        operatingDays={vendor.operating_days ?? []}
+        salesData={salesData}
+      />
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {itemsWithSlots.map((item) => (
-          <VendorMenuItemCard key={item.id} item={item} />
+        {itemsForCards.map((item) => (
+          <VendorMenuItemCard
+            key={item.id}
+            item={item}
+            slotStatus={slotStatuses.get(item.id) ?? "ok"}
+          />
         ))}
-        {itemsWithSlots.length === 0 && (
+        {itemsForCards.length === 0 && (
           <p className="text-muted-foreground text-center py-8">尚無餐點，請新增</p>
         )}
       </div>
     </div>
   );
+}
+
+async function fetchSalesData(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  itemIds: string[],
+  sinceDate: string,
+): Promise<SalesDataMap> {
+  if (itemIds.length === 0) return {};
+
+  const { data: salesRaw } = await supabase
+    .from("order_items")
+    .select("menu_item_id, date, qty, orders!inner(status)")
+    .in("menu_item_id", itemIds)
+    .gte("date", sinceDate);
+
+  const validStatuses = new Set(["confirmed", "completed", "picked_up"]);
+  const filtered = (salesRaw ?? []).filter(
+    (r) => validStatuses.has((r.orders as unknown as { status: string }).status)
+  );
+
+  // Group by menu_item_id → date → total qty
+  const byItem = new Map<string, Map<string, number>>();
+  for (const row of filtered) {
+    const itemMap = byItem.get(row.menu_item_id) ?? new Map();
+    itemMap.set(row.date, (itemMap.get(row.date) ?? 0) + row.qty);
+    byItem.set(row.menu_item_id, itemMap);
+  }
+
+  // Build SalesDataMap: 7 data points (one per day), fill missing days with 0
+  const result: SalesDataMap = {};
+  const days: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    days.push(new Date(Date.now() - i * 86400000).toISOString().split("T")[0]);
+  }
+
+  for (const itemId of itemIds) {
+    const itemMap = byItem.get(itemId);
+    if (!itemMap || itemMap.size === 0) {
+      result[itemId] = { dailySales: [0, 0, 0, 0, 0, 0, 0], avgPerDay: 0, daysWithData: 0 };
+      continue;
+    }
+    const dailySales = days.map((d) => itemMap.get(d) ?? 0);
+    const daysWithData = dailySales.filter((v) => v > 0).length;
+    const total = dailySales.reduce((a, b) => a + b, 0);
+    const avgPerDay = daysWithData > 0 ? total / daysWithData : 0;
+    result[itemId] = { dailySales, avgPerDay, daysWithData };
+  }
+
+  return result;
 }

--- a/app/vendor/menu/slot-banner.tsx
+++ b/app/vendor/menu/slot-banner.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { BulkSlotDialog, type BulkSlotItem, type SalesDataMap } from "./bulk-slot-dialog";
+
+interface Props {
+  show: boolean;
+  expiringCount: number;
+  items: BulkSlotItem[];
+  operatingDays: number[];
+  salesData: SalesDataMap;
+}
+
+export function SlotBanner({ show, expiringCount, items, operatingDays, salesData }: Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  if (!show && !successMessage) return null;
+
+  return (
+    <>
+      {successMessage ? (
+        <div className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
+          <span className="text-lg shrink-0">✅</span>
+          <div className="flex-1">
+            <p className="font-medium text-green-800 dark:text-green-200">{successMessage}</p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setSuccessMessage(null)}
+            className="shrink-0 text-green-700"
+          >
+            關閉
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
+          <span className="text-lg shrink-0">⚠️</span>
+          <div className="flex-1">
+            <p className="font-medium text-amber-800 dark:text-amber-200">
+              {expiringCount} 個餐點的訂餐名額即將用完
+            </p>
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              名額到期後使用者將無法訂餐。
+            </p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => setDialogOpen(true)}
+            className="shrink-0 bg-amber-700 hover:bg-amber-800 text-white"
+          >
+            建立未來名額
+          </Button>
+        </div>
+      )}
+
+      <BulkSlotDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        items={items}
+        operatingDays={operatingDays}
+        salesData={salesData}
+        onSuccess={setSuccessMessage}
+      />
+    </>
+  );
+}

--- a/app/vendor/menu/sparkline.tsx
+++ b/app/vendor/menu/sparkline.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 interface SparklineProps {
   data: number[];
   width?: number;

--- a/app/vendor/menu/sparkline.tsx
+++ b/app/vendor/menu/sparkline.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export function Sparkline({ data, width = 80, height = 24, className }: SparklineProps) {
+  if (data.length === 0) {
+    return (
+      <svg width={width} height={height} className={className}>
+        <line x1={0} y1={height / 2} x2={width} y2={height / 2} stroke="currentColor" strokeOpacity={0.2} strokeWidth={1.5} />
+      </svg>
+    );
+  }
+
+  const max = Math.max(...data, 1);
+  const padding = 2;
+  const innerH = height - padding * 2;
+  const step = data.length > 1 ? (width - padding * 2) / (data.length - 1) : 0;
+
+  const points = data
+    .map((v, i) => {
+      const x = padding + i * step;
+      const y = padding + innerH - (v / max) * innerH;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <svg width={width} height={height} className={className}>
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/docs/superpowers/plans/2026-04-15-bulk-slot-creation.md
+++ b/docs/superpowers/plans/2026-04-15-bulk-slot-creation.md
@@ -1,0 +1,992 @@
+# Bulk Slot Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a smart banner and bulk slot dialog to `/vendor/menu` so vendors can create daily slots for all menu items across two calendar weeks in one action.
+
+**Architecture:** Server Component (`page.tsx`) fetches vendor data, menu items with slots, and 7-day sales data, then passes everything to a client-side `SlotBanner` component. The banner shows when any item's farthest slot is ≤ 10 days away. Clicking "建立未來名額" opens a `BulkSlotDialog` with a 14-day grid (2 calendar weeks, Sunday-aligned). Save calls a batch `bulkUpsertSlots` Server Action.
+
+**Tech Stack:** Next.js 16 App Router, Supabase JS client, date-fns v4, shadcn/ui Dialog, Tailwind CSS 4
+
+**Spec:** `docs/superpowers/specs/2026-04-15-bulk-slot-creation-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `app/vendor/menu/sparkline.tsx` | Create | Pure SVG sparkline component (7 data points, ~80×24px) |
+| `app/vendor/menu/actions.ts` | Modify | Add `bulkUpsertSlots` Server Action |
+| `app/vendor/menu/bulk-slot-confirm-dialog.tsx` | Create | Confirmation dialog listing items using default qty |
+| `app/vendor/menu/bulk-slot-dialog.tsx` | Create | Main bulk slot dialog with per-item 14-day grids |
+| `app/vendor/menu/slot-banner.tsx` | Create | Client component: warning/success banner + dialog trigger |
+| `app/vendor/menu/menu-item-card.tsx` | Modify | Add `slotStatus` prop, render badge |
+| `app/vendor/menu/page.tsx` | Modify | Expand data fetching, compute slot statuses, render banner |
+
+---
+
+### Task 1: Sparkline SVG component
+
+**Files:**
+- Create: `app/vendor/menu/sparkline.tsx`
+
+- [ ] **Step 1: Create the sparkline component**
+
+```tsx
+// app/vendor/menu/sparkline.tsx
+"use client";
+
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export function Sparkline({ data, width = 80, height = 24, className }: SparklineProps) {
+  if (data.length === 0) {
+    return (
+      <svg width={width} height={height} className={className}>
+        <line x1={0} y1={height / 2} x2={width} y2={height / 2} stroke="currentColor" strokeOpacity={0.2} strokeWidth={1.5} />
+      </svg>
+    );
+  }
+
+  const max = Math.max(...data, 1);
+  const padding = 2;
+  const innerH = height - padding * 2;
+  const step = data.length > 1 ? (width - padding * 2) / (data.length - 1) : 0;
+
+  const points = data
+    .map((v, i) => {
+      const x = padding + i * step;
+      const y = padding + innerH - (v / max) * innerH;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <svg width={width} height={height} className={className}>
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 2: Verify sparkline renders**
+
+Run: `bunx next dev` (if not running)
+
+Open browser to any page and temporarily import the Sparkline to test. Or just verify no build errors:
+
+Run: `bunx next build --no-lint 2>&1 | head -20`
+
+We'll fully test this when integrating in Task 6.
+
+- [ ] **Step 3: Commit**
+
+```bash
+rtk git add app/vendor/menu/sparkline.tsx
+rtk git commit -m "feat(vendor): add Sparkline SVG component for sales trend display
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `bulkUpsertSlots` Server Action
+
+**Files:**
+- Modify: `app/vendor/menu/actions.ts`
+
+- [ ] **Step 1: Add the bulkUpsertSlots function**
+
+Add this function at the end of `app/vendor/menu/actions.ts` (before the final blank line):
+
+```ts
+export async function bulkUpsertSlots(
+  slots: { menu_item_id: string; date: string; max_qty: number }[]
+) {
+  const { supabase, vendor } = await requireVendor();
+
+  // Verify all menu items belong to this vendor
+  const itemIds = [...new Set(slots.map((s) => s.menu_item_id))];
+  const { data: ownedItems } = await supabase
+    .from("menu_items")
+    .select("id")
+    .eq("vendor_id", vendor.id)
+    .in("id", itemIds);
+
+  const ownedIds = new Set((ownedItems ?? []).map((i) => i.id));
+  const validSlots = slots.filter((s) => ownedIds.has(s.menu_item_id));
+
+  if (validSlots.length === 0) return { error: "沒有可建立的名額" };
+
+  const { error } = await supabase
+    .from("daily_slots")
+    .upsert(
+      validSlots.map((s) => ({
+        menu_item_id: s.menu_item_id,
+        date: s.date,
+        max_qty: s.max_qty,
+      })),
+      { onConflict: "menu_item_id,date" }
+    );
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/vendor/menu");
+  revalidatePath("/menu", "layout");
+  return { success: true, count: validSlots.length };
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `bunx next build --no-lint 2>&1 | tail -5`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+rtk git add app/vendor/menu/actions.ts
+rtk git commit -m "feat(vendor): add bulkUpsertSlots Server Action for batch slot creation
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Confirmation dialog
+
+**Files:**
+- Create: `app/vendor/menu/bulk-slot-confirm-dialog.tsx`
+
+- [ ] **Step 1: Create the confirmation dialog**
+
+This dialog lists items that still have untouched (default) slots and asks the vendor to confirm.
+
+```tsx
+// app/vendor/menu/bulk-slot-confirm-dialog.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+export interface UntouchedItem {
+  name: string;
+  defaultMaxQty: number;
+  untouchedCount: number;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: UntouchedItem[];
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+export function BulkSlotConfirmDialog({
+  open,
+  onOpenChange,
+  items,
+  onConfirm,
+  isPending,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>確認建立名額</DialogTitle>
+          <DialogDescription>
+            以下餐點尚有未設定的日期，儲存時將使用各餐點的預設供應量：
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="flex flex-col gap-1.5 text-sm">
+          {items.map((item) => (
+            <li key={item.name} className="flex justify-between">
+              <span>{item.name}</span>
+              <span className="text-muted-foreground">
+                {item.defaultMaxQty} 份/天（{item.untouchedCount} 天未設定）
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            取消
+          </Button>
+          <Button onClick={onConfirm} disabled={isPending}>
+            {isPending ? "建立中…" : "確認建立"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+rtk git add app/vendor/menu/bulk-slot-confirm-dialog.tsx
+rtk git commit -m "feat(vendor): add BulkSlotConfirmDialog for default-slot confirmation
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Bulk slot dialog
+
+**Files:**
+- Create: `app/vendor/menu/bulk-slot-dialog.tsx`
+
+This is the main dialog. It shows all menu items with sparklines and 14-day grids.
+
+- [ ] **Step 1: Create shared types at the top of the file**
+
+```tsx
+// app/vendor/menu/bulk-slot-dialog.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { startOfWeek, addDays, format } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import { useRef, useState, useTransition } from "react";
+import { bulkUpsertSlots } from "./actions";
+import { BulkSlotConfirmDialog, type UntouchedItem } from "./bulk-slot-confirm-dialog";
+import { Sparkline } from "./sparkline";
+
+type Slot = { id: string; date: string; max_qty: number; reserved_qty: number };
+
+export type BulkSlotItem = {
+  id: string;
+  name: string;
+  default_max_qty: number;
+  daily_slots: Slot[];
+};
+
+export type SalesDataMap = Record<
+  string,
+  { dailySales: number[]; avgPerDay: number; daysWithData: number }
+>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: BulkSlotItem[];
+  operatingDays: number[];
+  salesData: SalesDataMap;
+  onSuccess: (message: string) => void;
+}
+```
+
+- [ ] **Step 2: Implement date grid generation and cell state logic**
+
+Continue in the same file, add the helper functions and main component:
+
+```tsx
+const DAY_LABELS = ["日", "一", "二", "三", "四", "五", "六"];
+
+function generateDates(): string[] {
+  const today = new Date();
+  const sunday = startOfWeek(today, { weekStartsOn: 0 });
+  return Array.from({ length: 14 }, (_, i) =>
+    addDays(sunday, i).toISOString().split("T")[0]
+  );
+}
+
+type CellState = "existing" | "untouched" | "touched" | "disabled";
+
+function getCellState(
+  date: string,
+  today: string,
+  operatingDays: number[],
+  slotMap: Map<string, Slot>,
+  touchedSet: Set<string>,
+): CellState {
+  const dayOfWeek = new Date(date + "T00:00:00").getDay();
+  if (date <= today) return "disabled";
+  if (operatingDays.length > 0 && !operatingDays.includes(dayOfWeek)) return "disabled";
+  if (slotMap.has(date)) return touchedSet.has(date) ? "touched" : "existing";
+  return touchedSet.has(date) ? "touched" : "untouched";
+}
+```
+
+- [ ] **Step 3: Implement the BulkSlotDialog component body**
+
+Continue in the same file:
+
+```tsx
+export function BulkSlotDialog({
+  open,
+  onOpenChange,
+  items,
+  operatingDays,
+  salesData,
+  onSuccess,
+}: Props) {
+  const dates = generateDates();
+  const today = new Date().toISOString().split("T")[0];
+  const [isPending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Per-item, per-date qty overrides: itemId -> date -> qty
+  const [overrides, setOverrides] = useState<Record<string, Record<string, number>>>({});
+  // Track which cells user has manually edited
+  const [touched, setTouched] = useState<Record<string, Set<string>>>({});
+
+  function getQty(itemId: string, date: string, slotMap: Map<string, Slot>, defaultQty: number): number {
+    return overrides[itemId]?.[date] ?? slotMap.get(date)?.max_qty ?? defaultQty;
+  }
+
+  function handleQtyChange(itemId: string, date: string, value: string, defaultQty: number) {
+    const qty = parseInt(value);
+    if (isNaN(qty) || qty < 0) return;
+    setOverrides((prev) => ({
+      ...prev,
+      [itemId]: { ...prev[itemId], [date]: qty },
+    }));
+    setTouched((prev) => {
+      const next = new Map(Object.entries(prev).map(([k, v]) => [k, new Set(v)]));
+      const set = next.get(itemId) ?? new Set();
+      set.add(date);
+      next.set(itemId, set);
+      return Object.fromEntries(next);
+    });
+  }
+
+  function collectSlots(): { menu_item_id: string; date: string; max_qty: number }[] {
+    const slots: { menu_item_id: string; date: string; max_qty: number }[] = [];
+    for (const item of items) {
+      const slotMap = new Map(item.daily_slots.map((s) => [s.date, s]));
+      for (const date of dates) {
+        const state = getCellState(date, today, operatingDays, slotMap, touched[item.id] ?? new Set());
+        if (state === "disabled") continue;
+        const qty = getQty(item.id, date, slotMap, item.default_max_qty);
+        slots.push({ menu_item_id: item.id, date, max_qty: qty });
+      }
+    }
+    return slots;
+  }
+
+  function getUntouchedItems(): UntouchedItem[] {
+    const result: UntouchedItem[] = [];
+    for (const item of items) {
+      const slotMap = new Map(item.daily_slots.map((s) => [s.date, s]));
+      let count = 0;
+      for (const date of dates) {
+        const state = getCellState(date, today, operatingDays, slotMap, touched[item.id] ?? new Set());
+        if (state === "untouched") count++;
+      }
+      if (count > 0) {
+        result.push({ name: item.name, defaultMaxQty: item.default_max_qty, untouchedCount: count });
+      }
+    }
+    return result;
+  }
+
+  function handleSave() {
+    const untouched = getUntouchedItems();
+    if (untouched.length > 0) {
+      setConfirmOpen(true);
+      return;
+    }
+    doSave();
+  }
+
+  function doSave() {
+    const slots = collectSlots();
+    startTransition(async () => {
+      const result = await bulkUpsertSlots(slots);
+      setConfirmOpen(false);
+      if (result.error) {
+        alert(result.error);
+      } else {
+        const dateRange = `${format(new Date(dates.find((d) => d > today) ?? dates[0]), "M/d")}–${format(new Date(dates[dates.length - 1]), "M/d")}`;
+        onSuccess(`已成功建立 ${dateRange} 的名額（共 ${result.count} 筆）`);
+        onOpenChange(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-6xl max-h-[90dvh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>建立未來名額</DialogTitle>
+            <DialogDescription>
+              ℹ️ 黯淡的格子表示尚未設定名額，儲存時將使用預設供應量。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-6">
+            {items.map((item) => {
+              const slotMap = new Map(item.daily_slots.map((s) => [s.date, s]));
+              const sales = salesData[item.id];
+              const touchedSet = touched[item.id] ?? new Set<string>();
+
+              return (
+                <div key={item.id} className="border rounded-lg p-4 flex flex-col gap-3">
+                  {/* Header: name + sparkline + avg */}
+                  <div className="flex items-center gap-3">
+                    <span className="font-medium">{item.name}</span>
+                    {sales ? (
+                      <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Sparkline data={sales.dailySales} className="text-foreground" />
+                        {sales.daysWithData === 0
+                          ? "尚無銷售資料"
+                          : `近 ${sales.daysWithData} 天平均 ${sales.avgPerDay.toFixed(1)} 份/天`}
+                      </span>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">尚無銷售資料</span>
+                    )}
+                  </div>
+
+                  {/* 14-day grid: 2 rows of 7 */}
+                  {[0, 7].map((offset) => (
+                    <div key={offset} className="grid grid-cols-7 gap-2">
+                      {dates.slice(offset, offset + 7).map((date) => {
+                        const state = getCellState(date, today, operatingDays, slotMap, touchedSet);
+                        const slot = slotMap.get(date);
+                        const dayOfWeek = new Date(date + "T00:00:00").getDay();
+                        const isDisabled = state === "disabled";
+                        const isUntouched = state === "untouched";
+                        const displayQty = getQty(item.id, date, slotMap, item.default_max_qty);
+
+                        return (
+                          <div key={date} className="flex flex-col gap-1 items-center">
+                            <p className="text-xs text-muted-foreground">
+                              {DAY_LABELS[dayOfWeek]} {format(new Date(date + "T00:00:00"), "M/d")}
+                            </p>
+                            <Input
+                              type="number"
+                              min={0}
+                              value={displayQty}
+                              disabled={isDisabled}
+                              className={`w-full text-center px-1 ${
+                                isDisabled
+                                  ? "bg-muted text-muted-foreground opacity-50"
+                                  : isUntouched
+                                    ? "text-muted-foreground border-dashed"
+                                    : ""
+                              }`}
+                              onChange={(e) =>
+                                handleQtyChange(item.id, date, e.target.value, item.default_max_qty)
+                              }
+                            />
+                            {slot && slot.reserved_qty > 0 && (
+                              <p className="text-xs text-muted-foreground">已訂 {slot.reserved_qty}</p>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              取消
+            </Button>
+            <Button onClick={handleSave} disabled={isPending}>
+              {isPending ? "儲存中…" : "儲存名額"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <BulkSlotConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        items={getUntouchedItems()}
+        onConfirm={doSave}
+        isPending={isPending}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `bunx next build --no-lint 2>&1 | tail -10`
+
+Expected: Build succeeds. If `zhTW` import from `date-fns/locale` causes issues, remove it — the `format` call with `"M/d"` doesn't need a locale.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add app/vendor/menu/bulk-slot-dialog.tsx
+rtk git commit -m "feat(vendor): add BulkSlotDialog with 14-day grid and sales sparklines
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Slot banner client component
+
+**Files:**
+- Create: `app/vendor/menu/slot-banner.tsx`
+
+- [ ] **Step 1: Create the SlotBanner component**
+
+This is a Client Component that shows the warning/success banner and controls the dialog.
+
+```tsx
+// app/vendor/menu/slot-banner.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { BulkSlotDialog, type BulkSlotItem, type SalesDataMap } from "./bulk-slot-dialog";
+
+interface Props {
+  show: boolean;
+  expiringCount: number;
+  items: BulkSlotItem[];
+  operatingDays: number[];
+  salesData: SalesDataMap;
+}
+
+export function SlotBanner({ show, expiringCount, items, operatingDays, salesData }: Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  if (!show && !successMessage) return null;
+
+  return (
+    <>
+      {successMessage ? (
+        <div className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
+          <span className="text-lg shrink-0">✅</span>
+          <div className="flex-1">
+            <p className="font-medium text-green-800 dark:text-green-200">{successMessage}</p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setSuccessMessage(null)}
+            className="shrink-0 text-green-700"
+          >
+            關閉
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
+          <span className="text-lg shrink-0">⚠️</span>
+          <div className="flex-1">
+            <p className="font-medium text-amber-800 dark:text-amber-200">
+              {expiringCount} 個餐點的訂餐名額即將用完
+            </p>
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              名額到期後使用者將無法訂餐。
+            </p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => setDialogOpen(true)}
+            className="shrink-0 bg-amber-700 hover:bg-amber-800 text-white"
+          >
+            建立未來名額
+          </Button>
+        </div>
+      )}
+
+      <BulkSlotDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        items={items}
+        operatingDays={operatingDays}
+        salesData={salesData}
+        onSuccess={setSuccessMessage}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+rtk git add app/vendor/menu/slot-banner.tsx
+rtk git commit -m "feat(vendor): add SlotBanner with warning/success states and dialog trigger
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Menu item card badge
+
+**Files:**
+- Modify: `app/vendor/menu/menu-item-card.tsx`
+
+- [ ] **Step 1: Add slotStatus prop and render badge**
+
+The current `VendorMenuItemCard` component at `app/vendor/menu/menu-item-card.tsx` passes a `status` prop to the shared `MenuItemCard`. Add a `slotStatus` prop and render an additional badge.
+
+Replace the entire file content with:
+
+```tsx
+// app/vendor/menu/menu-item-card.tsx
+"use client";
+
+import { MenuItemCard } from "@/components/menu-item-card";
+import { useState } from "react";
+import { MenuItemEditDialog } from "./menu-item-edit-dialog";
+
+type Item = {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number;
+  is_available: boolean;
+  default_max_qty: number;
+  image_url: string | null;
+  calories: number | null;
+  protein: number | null;
+  sodium: number | null;
+  sugar: number | null;
+  tags: string[];
+  daily_slots: { id: string; date: string; max_qty: number; reserved_qty: number }[];
+  item_option_groups: {
+    id: string; name: string; required: boolean; max_select: number; sort_order: number;
+    item_options: { id: string; name: string; price_delta: number; sort_order: number }[];
+  }[];
+};
+
+export type SlotStatus = "expiring" | "none" | "ok";
+
+export function VendorMenuItemCard({ item, slotStatus }: { item: Item; slotStatus: SlotStatus }) {
+  const [editOpen, setEditOpen] = useState(false);
+
+  const badge = (
+    <div className="flex flex-wrap gap-1.5">
+      {!item.is_available && (
+        <span className="text-xs text-muted-foreground border rounded-full px-2 py-0.5">已下架</span>
+      )}
+      {slotStatus === "none" && (
+        <span className="text-xs text-red-600 border border-red-200 bg-red-50 rounded-full px-2 py-0.5 dark:text-red-400 dark:border-red-900 dark:bg-red-950">無名額</span>
+      )}
+      {slotStatus === "expiring" && (
+        <span className="text-xs text-amber-600 border border-amber-200 bg-amber-50 rounded-full px-2 py-0.5 dark:text-amber-400 dark:border-amber-900 dark:bg-amber-950">名額將盡</span>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      <MenuItemEditDialog item={item} open={editOpen} onOpenChange={setEditOpen} />
+      <MenuItemCard
+        item={item}
+        onClick={() => setEditOpen(true)}
+        status={badge}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+rtk git add app/vendor/menu/menu-item-card.tsx
+rtk git commit -m "feat(vendor): add slot status badge (名額將盡/無名額) to menu item cards
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: page.tsx — data fetching, slot status, banner integration
+
+**Files:**
+- Modify: `app/vendor/menu/page.tsx`
+
+This is the main integration task. The page needs to:
+1. Add `operating_days` to vendor query
+2. Fetch 7-day sales data
+3. Compute slot status per item
+4. Render the SlotBanner
+5. Pass `slotStatus` to each card
+
+- [ ] **Step 1: Rewrite page.tsx with all new data fetching and integration**
+
+Replace the entire file content of `app/vendor/menu/page.tsx`:
+
+```tsx
+// app/vendor/menu/page.tsx
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { VendorMenuItemCard, type SlotStatus } from "./menu-item-card";
+import { SlotBanner } from "./slot-banner";
+import type { BulkSlotItem, SalesDataMap } from "./bulk-slot-dialog";
+
+const EXPIRY_THRESHOLD_DAYS = 10;
+
+export default async function VendorMenuPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: vendor } = await supabase
+    .from("vendors")
+    .select("id, name, operating_days")
+    .eq("owner_id", user.id)
+    .single();
+
+  if (!vendor) {
+    return <p className="text-muted-foreground">尚未綁定商家帳號，請聯絡管理員。</p>;
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+  const sevenDaysLater = new Date(Date.now() + 7 * 86400000).toISOString().split("T")[0];
+  const thresholdDate = new Date(Date.now() + EXPIRY_THRESHOLD_DAYS * 86400000).toISOString().split("T")[0];
+
+  // Fetch all items with their slots (Supabase fetches all embedded rows)
+  const { data: items } = await supabase
+    .from("menu_items")
+    .select("id, name, description, price, is_available, default_max_qty, image_url, calories, protein, sodium, sugar, tags, daily_slots(id, date, max_qty, reserved_qty), item_option_groups(id, name, required, max_select, sort_order, item_options(id, name, price_delta, sort_order))")
+    .eq("vendor_id", vendor.id)
+    .order("name");
+
+  const allItems = items ?? [];
+
+  // Fetch 7-day sales data
+  const sevenDaysAgo = new Date(Date.now() - 7 * 86400000).toISOString().split("T")[0];
+  const itemIds = allItems.map((i) => i.id);
+  const salesData = await fetchSalesData(supabase, itemIds, sevenDaysAgo);
+
+  // Compute slot status per item
+  const slotStatuses = new Map<string, SlotStatus>();
+  const availableItems = allItems.filter((i) => i.is_available);
+  let expiringCount = 0;
+
+  for (const item of allItems) {
+    if (!item.is_available) {
+      slotStatuses.set(item.id, "ok");
+      continue;
+    }
+    const futureSlots = (item.daily_slots ?? []).filter((s) => s.date > today);
+    if (futureSlots.length === 0) {
+      slotStatuses.set(item.id, "none");
+      expiringCount++;
+      continue;
+    }
+    const farthest = futureSlots.reduce((a, b) => (a.date > b.date ? a : b));
+    if (farthest.date <= thresholdDate) {
+      slotStatuses.set(item.id, "expiring");
+      expiringCount++;
+    } else {
+      slotStatuses.set(item.id, "ok");
+    }
+  }
+
+  const showBanner = expiringCount > 0;
+
+  // Prepare data for card display (7-day filtered slots)
+  const itemsForCards = allItems.map((item) => ({
+    ...item,
+    daily_slots: (item.daily_slots ?? []).filter(
+      (s) => s.date > today && s.date <= sevenDaysLater
+    ),
+  }));
+
+  // Prepare data for bulk dialog (all slots, only available items)
+  const bulkDialogItems: BulkSlotItem[] = availableItems.map((item) => ({
+    id: item.id,
+    name: item.name,
+    default_max_qty: item.default_max_qty,
+    daily_slots: item.daily_slots ?? [],
+  }));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">{vendor.name} — 菜單管理</h1>
+        <Button size="sm">新增餐點</Button>
+      </div>
+
+      <SlotBanner
+        show={showBanner}
+        expiringCount={expiringCount}
+        items={bulkDialogItems}
+        operatingDays={vendor.operating_days ?? []}
+        salesData={salesData}
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {itemsForCards.map((item) => (
+          <VendorMenuItemCard
+            key={item.id}
+            item={item}
+            slotStatus={slotStatuses.get(item.id) ?? "ok"}
+          />
+        ))}
+        {itemsForCards.length === 0 && (
+          <p className="text-muted-foreground text-center py-8">尚無餐點，請新增</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+async function fetchSalesData(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  itemIds: string[],
+  sinceDate: string,
+): Promise<SalesDataMap> {
+  if (itemIds.length === 0) return {};
+
+  const { data: salesRaw } = await supabase
+    .from("order_items")
+    .select("menu_item_id, date, qty, orders!inner(status)")
+    .in("menu_item_id", itemIds)
+    .gte("date", sinceDate);
+
+  const validStatuses = new Set(["confirmed", "completed", "picked_up"]);
+  const filtered = (salesRaw ?? []).filter(
+    (r) => validStatuses.has((r.orders as unknown as { status: string }).status)
+  );
+
+  // Group by menu_item_id → date → total qty
+  const byItem = new Map<string, Map<string, number>>();
+  for (const row of filtered) {
+    const itemMap = byItem.get(row.menu_item_id) ?? new Map();
+    itemMap.set(row.date, (itemMap.get(row.date) ?? 0) + row.qty);
+    byItem.set(row.menu_item_id, itemMap);
+  }
+
+  // Build SalesDataMap: 7 data points (one per day), fill missing days with 0
+  const result: SalesDataMap = {};
+  const days: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    days.push(new Date(Date.now() - i * 86400000).toISOString().split("T")[0]);
+  }
+
+  for (const itemId of itemIds) {
+    const itemMap = byItem.get(itemId);
+    if (!itemMap || itemMap.size === 0) {
+      result[itemId] = { dailySales: [0, 0, 0, 0, 0, 0, 0], avgPerDay: 0, daysWithData: 0 };
+      continue;
+    }
+    const dailySales = days.map((d) => itemMap.get(d) ?? 0);
+    const daysWithData = dailySales.filter((v) => v > 0).length;
+    const total = dailySales.reduce((a, b) => a + b, 0);
+    const avgPerDay = daysWithData > 0 ? total / daysWithData : 0;
+    result[itemId] = { dailySales, avgPerDay, daysWithData };
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npx next build --no-lint 2>&1 | tail -10`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Manual verification**
+
+Start dev server: `npx next dev`
+
+1. Log in as vendor (`uncle.bento@nycueats.dev` / `password123`)
+2. Navigate to `/vendor/menu`
+3. **Banner**: If any items have slots expiring within 10 days, the amber banner should appear
+4. **Card badges**: Items with expiring/no slots show orange "名額將盡" or red "無名額" badges
+5. Click **「建立未來名額」**:
+   - Dialog opens with all available items
+   - Each item shows sparkline + average (or "尚無銷售資料")
+   - 14-day grid: 2 rows × 7, Sunday-aligned
+   - Past dates are greyed/disabled but show existing data
+   - Non-operating days are greyed/disabled
+   - Untouched future cells show dashed border with default qty
+6. Edit some cells, click **「儲存名額」**:
+   - If any untouched cells remain → confirmation dialog appears listing each item's default qty and count
+   - Click 「取消」→ returns to edit view (no data loss)
+   - Click 「確認建立」→ saves, dialog closes, banner turns green with success message
+7. Reload page: banner should be gone (if all items now have sufficient slots)
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add app/vendor/menu/page.tsx
+rtk git commit -m "feat(vendor): integrate slot banner, sales data, and status badges in menu page
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+### Spec coverage
+
+| Spec requirement | Task |
+|-----------------|------|
+| Banner trigger (≤ 10 days) | Task 7: `EXPIRY_THRESHOLD_DAYS = 10`, computed in page.tsx |
+| Banner content (warning + count) | Task 5: SlotBanner warning state |
+| Banner success state (green) | Task 5: SlotBanner success state |
+| Card badge (名額將盡 / 無名額) | Task 6: VendorMenuItemCard slotStatus prop |
+| Dialog structure (full-width, scrollable) | Task 4: `sm:max-w-6xl max-h-[90dvh] overflow-y-auto` |
+| Tip at dialog top | Task 4: DialogDescription with ℹ️ |
+| 14 calendar days, Sunday-aligned | Task 4: `startOfWeek(today, { weekStartsOn: 0 })` + 14 days |
+| Past dates greyed, show historical data | Task 4: `getCellState` returns "disabled" for `date <= today`, Input shows existing slot data |
+| Non-operating days greyed | Task 4: `getCellState` checks `operatingDays` |
+| Untouched cells dashed/dim | Task 4: `border-dashed text-muted-foreground` class |
+| Confirmation dialog with per-item defaults | Task 3: BulkSlotConfirmDialog lists each item |
+| Cancel → back to edit (no data loss) | Task 3+4: `setConfirmOpen(false)`, state preserved |
+| Sparkline + average | Task 1 (component) + Task 4+7 (integration) |
+| Sales display logic (0 / 1-6 / 7 days) | Task 7: `fetchSalesData` computes `daysWithData` |
+| bulkUpsertSlots Server Action | Task 2 |
+| revalidate vendor + user paths | Task 2: both paths revalidated |
+| operating_days null → all days open | Task 4: `operatingDays.length > 0 && !operatingDays.includes(...)` |
+
+### Placeholder scan
+
+No TBD, TODO, or "implement later" found. All steps contain complete code.
+
+### Type consistency
+
+- `BulkSlotItem` defined in `bulk-slot-dialog.tsx`, exported and used in `slot-banner.tsx` and `page.tsx` ✓
+- `SalesDataMap` defined in `bulk-slot-dialog.tsx`, exported and used in `slot-banner.tsx` and `page.tsx` ✓
+- `SlotStatus` defined in `menu-item-card.tsx`, exported and used in `page.tsx` ✓
+- `UntouchedItem` defined in `bulk-slot-confirm-dialog.tsx`, exported and used in `bulk-slot-dialog.tsx` ✓
+- `bulkUpsertSlots` signature matches usage: `{ menu_item_id, date, max_qty }[]` ✓

--- a/docs/superpowers/specs/2026-04-15-bulk-slot-creation-design.md
+++ b/docs/superpowers/specs/2026-04-15-bulk-slot-creation-design.md
@@ -1,0 +1,183 @@
+# 批次名額建立（Bulk Slot Creation）設計文件
+
+## 問題
+
+商家的 `daily_slots` 只在手動開啟編輯 Dialog 並 blur 輸入框時才會寫入 DB。一旦已建立的 slot 日期全部過期，使用者就無法訂餐，直到商家重新手動設定。這造成每週都需要重複操作，容易遺漏。
+
+## 解決方案概述
+
+在 `/vendor/menu` 菜單管理頁面新增一個**智慧 Banner + 批次名額設定 Dialog**，讓商家一次設定所有餐點未來 14 天的名額。
+
+## 設計決策
+
+| 決策 | 選擇 | 原因 |
+|------|------|------|
+| 觸發方式 | 半自動（Banner + 按鈕） | 商家主動操作，不意外覆蓋已有設定 |
+| 實作策略 | Server Action 批次 upsert | 與現有 `setDailySlot` 模式一致，不需新增 DB function |
+| 天數範圍 | 14 個日曆天 | 2 排 × 7 天排版整齊，非營業日灰掉，直覺呈現「這週和下週」 |
+
+---
+
+## Banner 元件
+
+### 觸發條件
+
+針對所有 `is_available = true` 的餐點，取其 `daily_slots` 中最遠的日期。若最遠日期距今 ≤ 10 天（或完全沒有未來 slot），則顯示 Banner。
+
+> 使用者需要提前 7 天訂餐，所以 10 天閾值提供 3 天緩衝。
+
+### Banner 內容
+
+```
+⚠️  {N} 個餐點的訂餐名額即將用完
+    名額到期後使用者將無法訂餐。
+                              [建立未來名額]
+```
+
+### 成功狀態
+
+儲存完成後，Banner 變為綠色成功訊息（例：「已成功建立 4/16–4/26 的名額」），頁面同時 revalidate。
+
+---
+
+## 餐點卡片 Badge
+
+在 `VendorMenuItemCard` 的餐點名稱旁顯示小標籤：
+
+| 狀態 | Badge | 顏色 |
+|------|-------|------|
+| slot ≤ 10 天 | `名額將盡` | 橘色（warning） |
+| 完全無未來 slot | `無名額` | 紅色（destructive） |
+| 名額充足（> 10 天） | 不顯示 | — |
+
+---
+
+## 批次名額設定 Dialog
+
+### 開啟方式
+
+點擊 Banner 上的「建立未來名額」按鈕。
+
+### 結構
+
+全寬 Dialog（`sm:max-w-6xl`），可捲動。頂部顯示一次 tip，接著每個 `is_available = true` 的餐點為一個區塊：
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  建立未來名額                                       [✕]  │
+│                                                          │
+│  ℹ️ 黯淡的格子表示尚未設定名額，儲存時將使用預設供應量。     │
+│                                                          │
+│  ┌─ {餐點名稱} ────────────────────────────────────────┐ │
+│  │  📈 ▁▂▃▅▃▂▄  近 7 天平均 8.2 份/天                  │ │
+│  │                                                      │ │
+│  │    日     一     二     三     四     五     六       │ │
+│  │   4/13   4/14   4/15   4/16   4/17   4/18   4/19    │ │
+│  │   [10]   [10]   [10]   [10]   [══]   [══]   [10]    │ │
+│  │    已8    已5    已3                                  │ │
+│  │                                                      │ │
+│  │   4/20   4/21   4/22   4/23   4/24   4/25   4/26    │ │
+│  │   {10}   {10}   {10}   {10}   [══]   [══]   {10}    │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                          │
+│                                    [取消]  [儲存名額]     │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 格子狀態
+
+| 樣式 | 意義 | 互動 |
+|------|------|------|
+| `[10]` 正常色 | DB 已有 slot | 可編輯 |
+| `{10}` 暗淡色 | DB 無 slot，預填 `default_max_qty` | 可編輯，修改後變正常色 |
+| `[══]` 灰底 | 非營業日（不在 `operating_days`）或過去日期 | 禁用 |
+| `已訂N` 小字 | 已有訂單數量 | 僅顯示，出現在有 slot 的格子下方 |
+
+### 日期範圍與排列
+
+- 兩排固定以**週日為第一天**，呈現兩個完整日曆週
+- 第一排：本週（包含今天所在的那一週，日～六）
+- 第二排：下週（日～六）
+- **過去日期**：灰底禁用，但仍顯示已設定名額與已訂數量（作為歷史參考）
+- **非營業日**：灰底禁用
+- 若 `operating_days` 為 null 或空陣列 → 視為全週營業，僅過去日期灰掉
+
+---
+
+## 儲存流程
+
+```
+使用者按「儲存名額」
+  │
+  ├─ 檢查是否有 untouched 的暗淡格子
+  │    │
+  │    ├─ 有 → 開啟確認 Dialog
+  │    │        內容：
+  │    │          「以下餐點尚有未設定的日期，
+  │    │           儲存時將使用各餐點的預設供應量：
+  │    │            - 排骨便當：10 份/天（5 天未設定）
+  │    │            - 雞腿便當：8 份/天（5 天未設定）」
+  │    │
+  │    │        [取消] → 回到編輯畫面，不丟失已編輯內容
+  │    │        [確認建立] → 繼續儲存
+  │    │
+  │    └─ 無 → 直接儲存
+  │
+  ↓
+呼叫 bulkUpsertSlots Server Action
+  → supabase.from('daily_slots').upsert(slots[], { onConflict: 'menu_item_id,date' })
+  → revalidatePath('/vendor/menu')
+  → revalidatePath('/menu', 'layout')  // 使用者端菜單頁也需刷新
+  ↓
+成功 → 關閉 Dialog，Banner 變為綠色成功訊息，頁面刷新
+```
+
+---
+
+## 銷量趨勢
+
+### 資料查詢
+
+```sql
+SELECT oi.menu_item_id,
+       o.created_at::date AS day,
+       SUM(oi.quantity)   AS qty
+FROM   order_items oi
+JOIN   orders o ON o.id = oi.order_id
+WHERE  o.created_at >= NOW() - INTERVAL '7 days'
+  AND  o.status IN ('confirmed', 'completed', 'picked_up')
+GROUP  BY oi.menu_item_id, day
+```
+
+### 顯示邏輯
+
+| 有資料天數 | 顯示 |
+|-----------|------|
+| 0 天 | 「尚無銷售資料」+ 灰色平坦線 |
+| 1–6 天 | 「近 {N} 天平均 {avg} 份/天」+ sparkline（無資料日補 0） |
+| 7 天 | 「近 7 天平均 {avg} 份/天」+ sparkline |
+
+### Sparkline
+
+- 純 SVG 內嵌，不引入第三方圖表庫
+- 7 個資料點，約 80×24px
+- 無資料日補 0
+
+---
+
+## 修改清單
+
+| 檔案 | 操作 | 說明 |
+|------|------|------|
+| `app/vendor/menu/page.tsx` | 修改 | vendor 查詢加 `operating_days`；加銷量查詢；計算到期狀態；渲染 Banner |
+| `app/vendor/menu/actions.ts` | 修改 | 新增 `bulkUpsertSlots` Server Action |
+| `app/vendor/menu/bulk-slot-dialog.tsx` | 新增 | 批次名額設定 Dialog |
+| `app/vendor/menu/bulk-slot-confirm-dialog.tsx` | 新增 | 儲存確認彈窗 |
+| `app/vendor/menu/sparkline.tsx` | 新增 | 純 SVG sparkline 元件 |
+| `app/vendor/menu/menu-item-card.tsx` | 修改 | 接收到期狀態 prop，顯示 badge |
+
+### 不修改
+
+- `menu-item-edit-dialog.tsx` — 單一餐點編輯照舊
+- DB schema — 不需要 migration，現有 `daily_slots` 結構已足夠
+- RLS — 現有 vendor 的 INSERT/UPDATE policy 已涵蓋


### PR DESCRIPTION
## Summary

- 新增 **名額到期 Banner**：當任何上架餐點的最遠名額距今 ≤ 10 天，在菜單管理頁顯示琥珀色警告 Banner
- 新增 **「建立未來名額」Dialog**：一次為所有餐點設定 14 天（週日對齊）的每日名額，包含銷售趨勢 sparkline、黯淡格子（預設值）提示、確認彈窗、儲存後顯示成功訊息
- 新增卡片狀態 badge：`名額將盡`（琥珀）/ `無名額`（紅色）

## Test plan
- [ ] 以 `uncle.bento@nycueats.dev` 登入，進入 `/vendor/menu`，確認有餐點名額即將到期時出現琥珀色 Banner
- [ ] 點擊「建立未來名額」，確認 Dialog 顯示所有上架餐點、14 天格子（週日起算）、銷售 sparkline
- [ ] 黯淡格子（未設定）儲存前跳出確認彈窗，取消後回到編輯畫面且資料不遺失
- [ ] 儲存後 Banner 變綠並顯示成功訊息，重新整理後 Banner 消失（若名額已足夠）
- [ ] 名額不足的餐點卡片顯示正確 badge（`名額將盡` / `無名額`）