### PR TITLE
Automatic linting after commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "agent",
+            "if": "Bash(git commit*)",
+            "prompt": "$ARGUMENTS\nA git commit command just completed in this repository. Spawn a subagent now. The subagent must run bun run lint, fix all lint errors, rerun bun run lint until it passes, and then combine the changes into the commit automatically."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/post_commit_lint_hint.py\"",
+            "statusMessage": "Checking post-commit lint workflow",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/post_commit_lint_hint.py
+++ b/.codex/hooks/post_commit_lint_hint.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+
+def extract_command(payload: dict) -> str:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        cmd = tool_input.get("command")
+        if isinstance(cmd, str):
+            return cmd
+
+    tool_args = payload.get("toolArgs")
+    if isinstance(tool_args, str):
+        try:
+            parsed = json.loads(tool_args)
+            cmd = parsed.get("command")
+            if isinstance(cmd, str):
+                return cmd
+        except json.JSONDecodeError:
+            pass
+    elif isinstance(tool_args, dict):
+        cmd = tool_args.get("command")
+        if isinstance(cmd, str):
+            return cmd
+
+    return ""
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return 0
+
+    command = extract_command(payload).strip()
+    if not command.startswith("git commit"):
+        return 0
+
+    response = {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": (
+                "A git commit command just completed. Spawn a subagent now. "
+                "The subagent must run bun run lint, fix all lint errors in this repository, "
+                "rerun bun run lint until it passes, and then report changed files. "
+                "Do not create commits automatically."
+            )
+        },
+        "systemMessage": "Post-commit lint subagent requested."
+    }
+    print(json.dumps(response))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/hooks/lint-after-commit.json
+++ b/.github/hooks/lint-after-commit.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/scripts/post-commit-lint-subagent.sh",
+        "cwd": ".",
+        "timeout": 120
+      }
+    ]
+  }
+}

--- a/.github/hooks/scripts/post-commit-lint-subagent.sh
+++ b/.github/hooks/scripts/post-commit-lint-subagent.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT="$(cat)"
+if [[ -z "${INPUT// }" ]]; then
+  exit 0
+fi
+
+COMMAND="$(HOOK_INPUT="$INPUT" python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("HOOK_INPUT", "").strip()
+if not raw:
+    print("")
+    raise SystemExit(0)
+
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError:
+    print("")
+    raise SystemExit(0)
+
+command = ""
+
+tool_args = payload.get("toolArgs")
+if isinstance(tool_args, str):
+    try:
+        parsed = json.loads(tool_args)
+        command = parsed.get("command") or ""
+    except json.JSONDecodeError:
+        command = ""
+elif isinstance(tool_args, dict):
+    command = tool_args.get("command") or ""
+
+if not command:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command") or ""
+
+print(command)
+PY
+)"
+
+if [[ ! "$COMMAND" =~ ^git[[:space:]]+commit ]]; then
+  exit 0
+fi
+
+cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "A git commit command just completed. Spawn a subagent now. The subagent must run bun run lint, fix all lint errors, rerun bun run lint until it passes, and then combine the changes into the commit automatically."
+  },
+  "systemMessage": "Post-commit lint subagent requested."
+}
+JSON


### PR DESCRIPTION
## What

- Introduced a mechanism to automatically run and fix lint issues after a git commit.

## Why

- Ensures code quality by preventing lint errors from being committed.
- Streamlines the development process by automating the linting workflow.

## How to test

- Make a commit in the repository and verify that linting runs automatically.
- Check that any lint errors are fixed before the commit is finalized.

