### PR TITLE
fix(auth): default vendor and admin logins to backoffice

### DIFF
--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getDefaultHomePath } from "@/lib/navigation-rules";
 import { createClient } from "@/lib/supabase/server";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
@@ -8,7 +9,22 @@ export async function signInWithEmail(email: string, password: string) {
   const supabase = await createClient();
   const { error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) return { error: error.message };
-  redirect("/");
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  redirect(getDefaultHomePath(profile?.role ?? []));
 }
 
 export async function signInWithGoogle() {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { getHeaderNavigation } from "@/lib/navigation-rules";
 import { createClient } from "@/lib/supabase/server";
 import { ClipboardList, ShoppingBasket } from "lucide-react";
 import Link from "next/link";
@@ -16,8 +17,7 @@ export async function Header() {
     ? (await supabase.from("profiles").select("avatar_url, name, area_id, role").eq("id", user.id).single()).data
     : null;
 
-  const isVendor = profile?.role?.includes("vendor") ?? false;
-  const isAdmin = profile?.role?.includes("admin") ?? false;
+  const navigation = getHeaderNavigation(profile?.role ?? []);
 
   // 依 city 分組
   type AreaRow = { id: string; name: string; city: string };
@@ -36,26 +36,35 @@ export async function Header() {
         <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />
       </div>
       <div className="flex items-center gap-4">
-        {isVendor && (
+        {navigation.showVendorDashboard && (
           <Link href="/vendor">
             <Button variant="outline" size="sm">商家後台</Button>
           </Link>
         )}
-        {isAdmin && (
+        {navigation.showOrderCatalog && (
+          <Link href="/">
+            <Button variant="outline" size="sm">點餐目錄</Button>
+          </Link>
+        )}
+        {navigation.showAdminDashboard && (
           <Link href="/admin">
             <Button variant="outline" size="sm">管理後台</Button>
           </Link>
         )}
-        <Link href="/orders">
-          <Button variant="outline">
-            <ClipboardList className="size-4" />
-          </Button>
-        </Link>
-        <Link href="/cart">
-          <Button variant="outline">
-            <ShoppingBasket className="size-4" />
-          </Button>
-        </Link>
+        {navigation.showOrders && (
+          <Link href="/orders">
+            <Button variant="outline">
+              <ClipboardList className="size-4" />
+            </Button>
+          </Link>
+        )}
+        {navigation.showCart && (
+          <Link href="/cart">
+            <Button variant="outline">
+              <ShoppingBasket className="size-4" />
+            </Button>
+          </Link>
+        )}
         {user ? (
           <Link href="/profile">
             <Avatar>

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -35,6 +35,13 @@ export default async function globalSetup() {
     throw new Error("Login did not redirect within 30s. Screenshot saved to test-results/global-setup-failure.png");
   }
 
+  const landingPath = new URL(page.url()).pathname;
+  if (landingPath.startsWith("/vendor") || landingPath.startsWith("/admin")) {
+    const orderCatalogButton = page.getByRole("button", { name: "點餐目錄" });
+    await orderCatalogButton.click();
+    await page.waitForURL("http://localhost:3000/", { timeout: 30000 });
+  }
+
   await page.context().storageState({ path: "e2e/.auth/user.json" });
   await browser.close();
 }

--- a/lib/navigation-rules.test.ts
+++ b/lib/navigation-rules.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { getDefaultHomePath, getHeaderNavigation } from "@/lib/navigation-rules";
+
+describe("navigation rules", () => {
+  it("routes pure vendors to the vendor dashboard by default", () => {
+    expect(getDefaultHomePath(["vendor"])).toBe("/vendor");
+  });
+
+  it("routes pure admins to the admin dashboard by default", () => {
+    expect(getDefaultHomePath(["admin"])).toBe("/admin");
+  });
+
+  it("keeps users on the ordering homepage", () => {
+    expect(getDefaultHomePath(["user"])).toBe("/");
+  });
+
+  it("prioritizes vendor over user and admin over vendor", () => {
+    expect(getDefaultHomePath(["vendor", "user"])).toBe("/vendor");
+    expect(getDefaultHomePath(["admin", "user"])).toBe("/admin");
+    expect(getDefaultHomePath(["vendor", "admin"])).toBe("/admin");
+    expect(getDefaultHomePath(["vendor", "admin", "user"])).toBe("/admin");
+  });
+
+  it("shows 點餐目錄 for vendor and admin accounts", () => {
+    expect(getHeaderNavigation(["user"])).toMatchObject({
+      showOrderCatalog: false,
+      showVendorDashboard: false,
+      showAdminDashboard: false,
+    });
+    expect(getHeaderNavigation(["admin"])).toMatchObject({
+      showOrderCatalog: true,
+      showVendorDashboard: false,
+      showAdminDashboard: true,
+    });
+    expect(getHeaderNavigation(["vendor"])).toMatchObject({
+      showOrderCatalog: true,
+      showVendorDashboard: true,
+      showAdminDashboard: false,
+    });
+    expect(getHeaderNavigation(["vendor", "admin"])).toMatchObject({
+      showOrderCatalog: true,
+      showVendorDashboard: true,
+      showAdminDashboard: true,
+    });
+  });
+
+  it("keeps cart and orders visible for all logged-in roles", () => {
+    expect(getHeaderNavigation(["user"])).toMatchObject({
+      showCart: true,
+      showOrders: true,
+    });
+    expect(getHeaderNavigation(["vendor"])).toMatchObject({
+      showCart: true,
+      showOrders: true,
+    });
+  });
+});

--- a/lib/navigation-rules.ts
+++ b/lib/navigation-rules.ts
@@ -1,0 +1,18 @@
+export function getDefaultHomePath(roles: string[]) {
+  if (roles.includes("admin")) return "/admin";
+  if (roles.includes("vendor")) return "/vendor";
+  return "/";
+}
+
+export function getHeaderNavigation(roles: string[]) {
+  const isVendor = roles.includes("vendor");
+  const isAdmin = roles.includes("admin");
+
+  return {
+    showVendorDashboard: isVendor,
+    showAdminDashboard: isAdmin,
+    showOrderCatalog: isVendor || isAdmin,
+    showCart: true,
+    showOrders: true,
+  };
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import { getDefaultHomePath } from "@/lib/navigation-rules";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function proxy(request: NextRequest) {
@@ -37,7 +38,13 @@ export async function proxy(request: NextRequest) {
   }
 
   if (user && pathname === "/login") {
-    return NextResponse.redirect(new URL("/", request.url));
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+
+    return NextResponse.redirect(new URL(getDefaultHomePath(profile?.role ?? []), request.url));
   }
 
   return response;


### PR DESCRIPTION
  ## Summary
  - default vendor logins to `/vendor`
  - default admin logins to `/admin`
  - keep access to the ordering homepage through a `點餐目錄` entry in the header
  - update Playwright global setup so employee-flow E2E tests always navigate back to the ordering homepage after login

  ## Changes
  - added shared navigation rules in `lib/navigation-rules.ts`
  - added coverage for default landing and header navigation behavior in `lib/navigation-rules.test.ts`
  - updated `app/login/actions.ts` to redirect by role priority after email login
  - updated `proxy.ts` so visiting `/login` while authenticated redirects to the correct default backoffice
  - updated `components/header.tsx`:
    - vendors see `商家後台` and `點餐目錄`
    - admins see `管理後台` and `點餐目錄`
  - updated `e2e/global-setup.ts` so if login lands on `/vendor` or `/admin`, Playwright clicks `點餐目錄` before storing auth state

  ## Behavior
  - default landing priority is `admin > vendor > user`
  - `admin` users land on `/admin`
  - `vendor` users land on `/vendor`
  - `user` users still land on `/`
  - vendor/admin accounts can still access the ordering homepage from the header

  ## Test Plan
  - [x] `bunx vitest run`
  - [x] `bunx eslint app/login/actions.ts components/header.tsx proxy.ts lib/navigation-rules.ts lib/navigation-rules.test.ts e2e/global-setup.ts`
  - [x] manually verified vendor and admin login landing behavior
  - [x] manually verified Playwright E2E flow still works after returning to `點餐目錄`
