### PR TITLE
chore(ci): drop e2e job until UI stabilizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,34 +24,3 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
-
-  e2e:
-    runs-on: ubuntu-latest
-    needs: lint-and-build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: bunx playwright install chromium --with-deps
-
-      - name: Run e2e tests
-        run: bun run test
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
-          E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
-          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 7


### PR DESCRIPTION
## Summary
- 移除 CI 的 `e2e` job，只保留 `lint-and-build`
- 開發階段 UI 還在頻繁迭代，e2e 維護成本 > 收益
- e2e 依賴的 shared Supabase `daily_slots` 沒人續，跑著跑著就過期，導致 main 的 red CI 跟 PR 內容無關（PR #71 / #73 就是這樣中標的）

## Why now
- 今天 PR #71 / #73 merge 後 e2e 紅
- 根因：`daily_slots` 最新日期 `2026-04-22`，今天 `2026-05-08`，過期 16 天 → 首頁所有餐點「本週已售完」→ locator 找不到可下單按鈕
- 治本（cron 自動補 slot / isolated test DB / pg_cron）成本高，先把火滅了再說

## Kept
- `e2e/` 資料夾、`playwright.config.ts`、`bun run test` 都保留
- 想跑就本地 `bun run test`，CI 暫時不卡

## Test plan
- [x] `cat .github/workflows/ci.yml` — 確認只剩 lint-and-build job