### PR TITLE
feat(ui): canvas/card surface hierarchy (PR 2/4)

### DIFF
--- a/app/admin/bar-chart.tsx
+++ b/app/admin/bar-chart.tsx
@@ -8,7 +8,7 @@ type Props = {
 export function BarChart({ title, items }: Props) {
   const max = Math.max(...items.map((i) => i.revenue), 1);
   return (
-    <div className="border rounded-lg p-4 flex flex-col gap-3">
+    <div className="border rounded-lg bg-card p-4 flex flex-col gap-3">
       <p className="text-sm font-bold">{title}</p>
       {items.length === 0 && <p className="text-sm text-muted-foreground">暫無資料</p>}
       {items.map((item) => (

--- a/app/admin/loading.tsx
+++ b/app/admin/loading.tsx
@@ -7,7 +7,7 @@ export default function AdminLoading() {
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="border rounded-lg p-4 flex flex-col gap-2">
+          <div key={i} className="border rounded-lg bg-card p-4 flex flex-col gap-2">
             <Skeleton className="h-3 w-20" />
             <Skeleton className="h-8 w-3/4" />
             <Skeleton className="h-3 w-1/2" />
@@ -15,14 +15,14 @@ export default function AdminLoading() {
         ))}
       </div>
 
-      <div className="border rounded-lg p-4 flex flex-col gap-2">
+      <div className="border rounded-lg bg-card p-4 flex flex-col gap-2">
         <Skeleton className="h-4 w-40" />
         <Skeleton className="h-40 w-full" />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {Array.from({ length: 2 }).map((_, i) => (
-          <div key={i} className="border rounded-lg p-4 flex flex-col gap-3">
+          <div key={i} className="border rounded-lg bg-card p-4 flex flex-col gap-3">
             <Skeleton className="h-4 w-32" />
             {Array.from({ length: 5 }).map((__, j) => (
               <div key={j} className="flex flex-col gap-1">

--- a/app/admin/reports/report-table.tsx
+++ b/app/admin/reports/report-table.tsx
@@ -77,7 +77,7 @@ export function ReportTable({ initialData, initialYear, initialMonth }: {
       )}
 
       {!isPending && data.length > 0 && (
-        <div className="border rounded-lg overflow-hidden">
+        <div className="border rounded-lg bg-card overflow-hidden">
           <table className="w-full">
             <thead>
               <tr className="border-b bg-muted/30">

--- a/app/admin/stat-card.tsx
+++ b/app/admin/stat-card.tsx
@@ -25,7 +25,7 @@ type Props = {
 export function StatCard({ title, value, prev, format }: Props) {
   const { label, positive } = diff(value, prev);
   return (
-    <div className="border rounded-lg p-4 flex flex-col gap-1">
+    <div className="border rounded-lg bg-card p-4 flex flex-col gap-1">
       <p className="text-sm text-muted-foreground">{title}</p>
       <p className="text-2xl font-bold">{formatValue(value, format)}</p>
       <p className={`text-xs ${positive ? "text-green-600" : "text-red-500"}`}>{label}</p>

--- a/app/admin/trend-chart.tsx
+++ b/app/admin/trend-chart.tsx
@@ -12,7 +12,7 @@ const PAD = { top: 12, right: 12, bottom: 24, left: 32 };
 export function TrendChart({ title, data }: Props) {
   if (data.length === 0) {
     return (
-      <div className="border rounded-lg p-4">
+      <div className="border rounded-lg bg-card p-4">
         <p className="text-sm font-bold mb-2">{title}</p>
         <p className="text-sm text-muted-foreground">暫無資料</p>
       </div>
@@ -34,7 +34,7 @@ export function TrendChart({ title, data }: Props) {
   const gridLines = [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(f * maxCount));
 
   return (
-    <div className="border rounded-lg p-4 flex flex-col gap-2">
+    <div className="border rounded-lg bg-card p-4 flex flex-col gap-2">
       <p className="text-sm font-bold">{title}</p>
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -19,7 +19,7 @@ export default async function AdminUsersPage() {
       {!profiles || profiles.length === 0 ? (
         <p className="text-muted-foreground text-center py-8">尚無使用者</p>
       ) : (
-        <div className="border rounded-lg overflow-hidden">
+        <div className="border rounded-lg bg-card overflow-hidden">
           <table className="w-full">
             <thead>
               <tr className="border-b bg-muted/30">

--- a/app/admin/vendors/[id]/area-editor.tsx
+++ b/app/admin/vendors/[id]/area-editor.tsx
@@ -69,7 +69,7 @@ export function AreaEditor({
                   className={`px-3 py-1 rounded-full text-sm border transition-all duration-200 ${
                     active
                       ? "bg-foreground text-background border-foreground"
-                      : "bg-background text-foreground border-border hover:border-foreground"
+                      : "bg-card text-foreground border-border hover:border-foreground"
                   }`}
                 >
                   {area.name}

--- a/app/cart/loading.tsx
+++ b/app/cart/loading.tsx
@@ -8,7 +8,7 @@ export default function CartLoading() {
         {Array.from({ length: 2 }).map((_, i) => (
           <div key={i} className="flex flex-col gap-2">
             <Skeleton className="h-4 w-28" />
-            <div className="border rounded-lg divide-y">
+            <div className="border rounded-lg bg-card divide-y">
               {Array.from({ length: 2 }).map((_, j) => (
                 <div key={j} className="flex items-center justify-between p-4">
                   <div className="flex flex-col gap-1.5">

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -46,7 +46,7 @@ export default async function CartPage() {
             <p className="text-sm font-medium text-muted-foreground">
               {format(new Date(date), "MM月dd日 EEEE", { locale: zhTW })}
             </p>
-            <div className="border rounded-lg divide-y">
+            <div className="border rounded-lg bg-card divide-y">
               {byDate[date].map((item) => (
                 <div key={item.id} className="flex items-center justify-between p-4">
                   <div className="flex flex-col gap-0.5">

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,7 +102,7 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
+  --background: oklch(0.97 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);

--- a/app/menu/[id]/loading.tsx
+++ b/app/menu/[id]/loading.tsx
@@ -14,7 +14,7 @@ export default function MenuLoading() {
         {/* 餐點卡片 */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="border rounded-lg flex justify-between h-40">
+            <div key={i} className="border rounded-lg bg-card flex justify-between h-40">
               <div className="flex flex-col p-4 gap-2 flex-1">
                 <Skeleton className="h-6 w-32" />
                 <Skeleton className="h-4 w-16" />

--- a/app/orders/[id]/loading.tsx
+++ b/app/orders/[id]/loading.tsx
@@ -8,7 +8,7 @@ export default function Loading() {
         <Skeleton className="h-4 w-32" />
         <Skeleton className="h-4 w-24" />
         {[1, 2, 3].map((i) => (
-          <div key={i} className="border rounded-lg p-4 flex flex-col gap-3">
+          <div key={i} className="border rounded-lg bg-card p-4 flex flex-col gap-3">
             <Skeleton className="h-4 w-3/4" />
             <Skeleton className="h-3 w-1/2" />
             <Skeleton className="h-3 w-1/3" />

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -93,7 +93,7 @@ export default async function OrderDetailPage({
             return (
               <div
                 key={item.id}
-                className="border rounded-lg p-4 flex flex-col gap-2"
+                className="border rounded-lg bg-card p-4 flex flex-col gap-2"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex items-start gap-2 flex-1">

--- a/app/orders/order-list.tsx
+++ b/app/orders/order-list.tsx
@@ -43,7 +43,7 @@ function OrderCard({ order }: { order: OrderSummary }) {
 
   return (
     <Link href={`/orders/${order.id}`}>
-      <div className="border rounded-lg p-4 flex flex-col gap-2 hover:scale-[1.02] transition-all duration-200">
+      <div className="border rounded-lg bg-card p-4 flex flex-col gap-2 hover:scale-[1.02] transition-all duration-200">
         <div className="flex items-center justify-between">
           <span className="text-sm font-mono text-muted-foreground">
             #{order.id.slice(0, 8)}

--- a/app/vendor/menu/bulk-slot-dialog.tsx
+++ b/app/vendor/menu/bulk-slot-dialog.tsx
@@ -174,7 +174,7 @@ export function BulkSlotDialog({
               const touchedSet = touched[item.id] ?? new Set<string>();
 
               return (
-                <div key={item.id} className="border rounded-lg p-4 flex flex-col gap-3">
+                <div key={item.id} className="border rounded-lg bg-card p-4 flex flex-col gap-3">
                   <div className="flex items-center gap-3">
                     <span className="font-medium">{item.name}</span>
                     {sales && sales.daysWithData > 0 ? (

--- a/app/vendor/menu/loading.tsx
+++ b/app/vendor/menu/loading.tsx
@@ -9,7 +9,7 @@ export default function VendorMenuLoading() {
       </div>
       <div className="flex flex-col gap-3">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="border rounded-lg p-4 flex flex-col gap-3">
+          <div key={i} className="border rounded-lg bg-card p-4 flex flex-col gap-3">
             <div className="flex justify-between items-center">
               <div className="flex flex-col gap-1.5">
                 <Skeleton className="h-5 w-32" />

--- a/app/vendor/menu/option-groups-editor.tsx
+++ b/app/vendor/menu/option-groups-editor.tsx
@@ -97,7 +97,7 @@ export function OptionGroupsEditor({ menuItemId, groups }: Props) {
       </div>
 
       {groups.map((group) => (
-        <div key={group.id} className="border rounded-lg p-3 flex flex-col gap-3">
+        <div key={group.id} className="border rounded-lg bg-card p-3 flex flex-col gap-3">
           {/* 群組 header */}
           <div className="flex items-center gap-2">
             <Input

--- a/app/vendor/orders/loading.tsx
+++ b/app/vendor/orders/loading.tsx
@@ -7,7 +7,7 @@ export default function VendorOrdersLoading() {
       {Array.from({ length: 3 }).map((_, i) => (
         <div key={i} className="flex flex-col gap-2">
           <Skeleton className="h-4 w-28" />
-          <div className="border rounded-lg divide-y">
+          <div className="border rounded-lg bg-card divide-y">
             {Array.from({ length: 2 }).map((_, j) => (
               <div key={j} className="flex items-center justify-between p-4">
                 <Skeleton className="h-4 w-24" />

--- a/app/vendor/orders/page.tsx
+++ b/app/vendor/orders/page.tsx
@@ -128,7 +128,7 @@ export default async function VendorOrdersPage({
             <p className="text-sm font-medium text-muted-foreground">
               {format(new Date(date), "MM月dd日 EEEE", { locale: zhTW })}
             </p>
-            <div className="border rounded-lg divide-y">
+            <div className="border rounded-lg bg-card divide-y">
               {groups.map((group) => (
                 <div key={group.name} className="flex flex-col gap-2 p-4">
                   <div className="flex items-center justify-between">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -28,7 +28,7 @@ export async function Header() {
   }, {});
 
   return (
-    <header className="sticky top-0 z-50 p-4 flex w-full items-center justify-between h-16 bg-background/20 backdrop-blur-sm border-b">
+    <header className="sticky top-0 z-50 p-4 flex w-full items-center justify-between h-16 bg-card/80 backdrop-blur-sm border-b">
       <div className="flex items-center gap-4">
         <Link href="/">
           <h1 className="text-xl font-bold">NYCU Eats</h1>

--- a/components/menu-item-card.tsx
+++ b/components/menu-item-card.tsx
@@ -23,7 +23,7 @@ export function MenuItemCard({ item, onClick, status, disabled }: Props) {
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`hover:scale-[1.02] transition-all duration-200 h-full border rounded-lg flex justify-between max-h-64 cursor-pointer text-left w-full ${disabled ? "opacity-50" : ""}`}
+      className={`hover:scale-[1.02] transition-all duration-200 h-full border rounded-lg bg-card flex justify-between max-h-64 cursor-pointer text-left w-full ${disabled ? "opacity-50" : ""}`}
     >
       <div className="flex flex-col p-4 gap-2 flex-1 min-w-0">
         <h2 className="text-xl font-bold">{item.name}</h2>

--- a/components/recommendation-section.tsx
+++ b/components/recommendation-section.tsx
@@ -19,7 +19,7 @@ export default function RecommendationSection({ title, items }: Props) {
             href={`/menu/${item.vendor_id}`}
             className="snap-start flex-shrink-0 w-48"
           >
-            <div className="border rounded-lg p-3 flex flex-col gap-2 h-full hover:scale-[1.02] transition-all duration-200">
+            <div className="border rounded-lg bg-card p-3 flex flex-col gap-2 h-full hover:scale-[1.02] transition-all duration-200">
               <p className="text-sm font-medium leading-tight line-clamp-2">{item.name}</p>
               <p className="text-xs text-muted-foreground">{item.vendor_name}</p>
               <p className="text-sm font-bold mt-auto">NT${item.price}</p>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border bg-card hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-modal bg-card p-4 text-sm shadow-floating duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

- DESIGN.md migration PR 2/4：建立 canvas (near-white) / card (pure-white) 的 surface 對比階層
- `--background` 從 `oklch(1 0 0)` 改為 `oklch(0.97 0 0)`
- 21 個 card-like 元件補上 `bg-card`，避免在新 canvas 上消失成透明
- 順手修正幾個誤用 `bg-background`：header sticky、button outline、area chip inactive
- Dialog 升級到新的 `rounded-modal` + `shadow-floating` token

## Test plan

- [x] `bun run lint` 過
- [x] `bun run build` compile 過
- [x] `bun run dev` smoke：`/` 307 → `/login`，`/login` 200
- [ ] PR merge 後實機開 light/dark 各跑一輪頁面，確認沒有元件「消失成透明」或「兩層白」

🤖 Generated with [Claude Code](https://claude.com/claude-code)