### PR TITLE
feat(ui): align core components to design tokens (PR 3/4)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,27 +70,27 @@ export default async function HomePage({ searchParams }: Props) {
             return (
               <Link key={vendor.id} href={`/menu/${vendor.id}`}>
                 <div className="hover:scale-[1.02] transition-all duration-200 w-full flex flex-col gap-3">
-                  <AspectRatio className="bg-muted rounded-lg overflow-hidden" ratio={16 / 9}>
+                  <AspectRatio className="bg-surface-placeholder rounded-card overflow-hidden" ratio={16 / 9}>
                     {vendor.image_url && (
                       <Image src={vendor.image_url} alt={vendor.name} fill sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw" className="object-cover" priority />
                     )}
                   </AspectRatio>
                   <div className="flex flex-col gap-1">
                     <div className="flex items-center gap-2">
-                      <p className="text-md font-medium">{vendor.name}</p>
+                      <p className="text-heading-sm font-semibold">{vendor.name}</p>
                       {!vendor.is_open && (
-                        <span className="text-xs text-muted-foreground border rounded-full px-2 py-0.5">暫停營業</span>
+                        <span className="text-caption text-muted-foreground border rounded-pill px-2 py-0.5">暫停營業</span>
                       )}
                     </div>
                     <div className="flex items-center gap-2 flex-wrap">
                       {rating && (
-                        <span className="text-sm text-muted-foreground flex items-center gap-1">
+                        <span className="text-meta text-muted-foreground flex items-center gap-1">
                           <HeartIcon className="size-3" />
                           {rating} ({total})
                         </span>
                       )}
                       {vendor.tags.map((tag) => (
-                        <span key={tag} className="text-xs text-muted-foreground border rounded-full px-2 py-0.5">
+                        <span key={tag} className="text-caption text-muted-foreground border rounded-pill px-2 py-0.5">
                           {tag}
                         </span>
                       ))}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -31,7 +31,7 @@ export async function Header() {
     <header className="sticky top-0 z-50 p-4 flex w-full items-center justify-between h-16 bg-card/80 backdrop-blur-sm border-b">
       <div className="flex items-center gap-4">
         <Link href="/">
-          <h1 className="text-xl font-bold">NYCU Eats</h1>
+          <h1 className="text-heading font-semibold tracking-tight">NYCU Eats</h1>
         </Link>
         <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />
       </div>

--- a/components/menu-item-card.tsx
+++ b/components/menu-item-card.tsx
@@ -23,18 +23,18 @@ export function MenuItemCard({ item, onClick, status, disabled }: Props) {
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`hover:scale-[1.02] transition-all duration-200 h-full border rounded-lg bg-card flex justify-between max-h-64 cursor-pointer text-left w-full ${disabled ? "opacity-50" : ""}`}
+      className={`hover:scale-[1.02] transition-all duration-200 h-full border rounded-card bg-card flex justify-between max-h-64 cursor-pointer text-left w-full ${disabled ? "opacity-50" : ""}`}
     >
       <div className="flex flex-col p-4 gap-2 flex-1 min-w-0">
-        <h2 className="text-xl font-bold">{item.name}</h2>
-        <p className="text-md">${item.price}</p>
+        <h2 className="text-heading-sm font-semibold">{item.name}</h2>
+        <p className="text-body font-semibold">${item.price}</p>
         {item.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2">{item.description}</p>
+          <p className="text-body text-muted-foreground line-clamp-2">{item.description}</p>
         )}
         <div className="flex flex-wrap items-center gap-3">
-          {item.calories && <p className="text-sm text-muted-foreground">熱量 {item.calories}kcal</p>}
-          {item.protein && <p className="text-sm text-muted-foreground">蛋白質 {item.protein}g</p>}
-          {item.sodium && <p className="text-sm text-muted-foreground">鈉 {item.sodium}mg</p>}
+          {item.calories && <p className="text-meta text-muted-foreground">熱量 {item.calories}kcal</p>}
+          {item.protein && <p className="text-meta text-muted-foreground">蛋白質 {item.protein}g</p>}
+          {item.sodium && <p className="text-meta text-muted-foreground">鈉 {item.sodium}mg</p>}
         </div>
         {status}
       </div>

--- a/components/recommendation-section.tsx
+++ b/components/recommendation-section.tsx
@@ -11,7 +11,7 @@ export default function RecommendationSection({ title, items }: Props) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-lg font-bold">{title}</h2>
+      <h2 className="text-heading font-semibold">{title}</h2>
       <div className="flex overflow-x-auto gap-3 pb-2 snap-x snap-mandatory [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         {items.map((item) => (
           <Link
@@ -19,14 +19,14 @@ export default function RecommendationSection({ title, items }: Props) {
             href={`/menu/${item.vendor_id}`}
             className="snap-start flex-shrink-0 w-48"
           >
-            <div className="border rounded-lg bg-card p-3 flex flex-col gap-2 h-full hover:scale-[1.02] transition-all duration-200">
-              <p className="text-sm font-medium leading-tight line-clamp-2">{item.name}</p>
-              <p className="text-xs text-muted-foreground">{item.vendor_name}</p>
-              <p className="text-sm font-bold mt-auto">NT${item.price}</p>
+            <div className="border rounded-card bg-card p-3 flex flex-col gap-2 h-full hover:scale-[1.02] transition-all duration-200">
+              <p className="text-heading-sm font-semibold leading-tight line-clamp-2">{item.name}</p>
+              <p className="text-meta text-muted-foreground">{item.vendor_name}</p>
+              <p className="text-body font-semibold mt-auto">NT${item.price}</p>
               {item.tags.length > 0 && (
                 <div className="flex flex-wrap gap-1">
                   {item.tags.slice(0, 3).map((tag) => (
-                    <span key={tag} className="text-xs border rounded-full px-2 py-0.5 text-muted-foreground">
+                    <span key={tag} className="text-caption border rounded-pill px-2 py-0.5 text-muted-foreground">
                       {tag}
                     </span>
                   ))}


### PR DESCRIPTION
## Summary

- DESIGN.md migration PR 3/4：把 home / vendor list / menu item / recommendation / header 五個關鍵入口套用新 token
- Cards：`rounded-lg` → `rounded-card`（16 → 20px）
- Tags/pills：`rounded-full` → `rounded-pill`（語意化）
- Typography：`text-xl/lg/md/sm/xs` → `text-heading/heading-sm/body/meta/caption`
- Weight：body-level 標題 `font-bold` → `font-semibold`（對齊 DESIGN.md「不用 700+ 除非 display/stat」）
- Vendor 圖片佔位：`bg-muted` → `bg-surface-placeholder`

範圍刻意保守 — 其他 admin/vendor/orders 卡片留待後續 review，避開單一 PR 視覺風險過大

## Test plan

- [x] `bun run lint` 過
- [x] `bun run build` compile 過
- [ ] Merge 後手動跑 `/`、`/menu/[id]`、`/orders` 確認 typography 與圓角無視覺塌陷

🤖 Generated with [Claude Code](https://claude.com/claude-code)