### PR TITLE
feat(ui): brand accent on logo + trending (PR 4/4)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,7 @@ export default async function HomePage({ searchParams }: Props) {
       <div className="max-w-6xl w-full p-4 flex flex-col gap-8">
         {(trending.length > 0 || nutritionPicks.length > 0 || randomPicks.length > 0) && (
           <div className="flex flex-col gap-6">
-            {trending.length > 0 && <RecommendationSection title="🔥 熱銷排行" items={trending} />}
+            {trending.length > 0 && <RecommendationSection title="🔥 熱銷排行" items={trending} accent />}
             {nutritionPicks.length > 0 && <RecommendationSection title="💪 營養推薦" items={nutritionPicks} />}
             {randomPicks.length > 0 && <RecommendationSection title="🎲 隨機探索" items={randomPicks} />}
           </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -31,7 +31,7 @@ export async function Header() {
     <header className="sticky top-0 z-50 p-4 flex w-full items-center justify-between h-16 bg-card/80 backdrop-blur-sm border-b">
       <div className="flex items-center gap-4">
         <Link href="/">
-          <h1 className="text-heading font-semibold tracking-tight">NYCU Eats</h1>
+          <h1 className="text-heading font-semibold tracking-tight">NYCU <span className="text-brand">Eats</span></h1>
         </Link>
         <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />
       </div>

--- a/components/recommendation-section.tsx
+++ b/components/recommendation-section.tsx
@@ -4,14 +4,18 @@ import type { RecommendedItem } from "@/lib/recommendation";
 interface Props {
   title: string;
   items: RecommendedItem[];
+  accent?: boolean;
 }
 
-export default function RecommendationSection({ title, items }: Props) {
+export default function RecommendationSection({ title, items, accent }: Props) {
   if (items.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-heading font-semibold">{title}</h2>
+      <h2 className="text-heading font-semibold flex items-center gap-2">
+        {accent && <span className="inline-block w-1 h-5 bg-brand rounded-full" aria-hidden />}
+        {title}
+      </h2>
       <div className="flex overflow-x-auto gap-3 pb-2 snap-x snap-mandatory [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         {items.map((item) => (
           <Link


### PR DESCRIPTION
## Summary

- DESIGN.md migration 收尾 PR — brand accent 番茄紅橘 `oklch(0.65 0.18 35)` 首次進入 UI
- Logo `NYCU Eats` 的 "Eats" 染 brand 色，成為品牌主錨點
- 熱銷排行區塊在標題前加一個 brand 直條，把「🔥 熱銷」做成視覺最大聲的推薦軌道
- 營養 / 隨機探索維持中性 — scarcity 才是 brand 的力量來源

## Test plan

- [x] `bun run lint` 過
- [x] `bun run build` compile 過
- [ ] Merge 後手動確認 dark mode 下 brand 色對比足夠（DESIGN.md Open Question #4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)