### PR TITLE
  feat(vendor): add revenue statistics dashboard

### DIFF
--- a/app/vendor/layout.tsx
+++ b/app/vendor/layout.tsx
@@ -29,6 +29,9 @@ export default async function VendorLayout({ children }: { children: React.React
           <Link href="/vendor/orders">
             <Button variant="outline" size="sm">訂單彙整</Button>
           </Link>
+          <Link href="/vendor/revenue">
+            <Button variant="outline" size="sm">營業額統計</Button>
+          </Link>
         </nav>
         {children}
       </div>

--- a/app/vendor/revenue/actions.ts
+++ b/app/vendor/revenue/actions.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { requireRole } from "@/lib/auth";
+
+import {
+  buildDailyRevenueTrend,
+  buildRevenueStats,
+  buildTopMenuItems,
+  getMonthRange,
+  getPreviousMonth,
+  type DailyRevenue,
+  type MenuRevenueRank,
+  type RevenueRow,
+  type RevenueStats,
+} from "./revenue-model";
+
+export type VendorRevenueDashboard = {
+  vendor: { id: string; name: string } | null;
+  stats: RevenueStats;
+  trend: DailyRevenue[];
+  topMenuItems: MenuRevenueRank[];
+};
+
+type OrderItemQueryRow = {
+  date: string;
+  qty: number;
+  unit_price: number;
+  order_id: string;
+  menu_item_id: string;
+  menu_items: { name: string; vendor_id: string } | null;
+  orders: { status: string } | null;
+};
+
+function emptyStats(): RevenueStats {
+  return {
+    thisMonth: { orders: 0, revenue: 0, soldQuantity: 0 },
+    lastMonth: { orders: 0, revenue: 0, soldQuantity: 0 },
+  };
+}
+
+function emptyDashboard(vendor: { id: string; name: string } | null): VendorRevenueDashboard {
+  return {
+    vendor,
+    stats: emptyStats(),
+    trend: buildDailyRevenueTrend([], 30),
+    topMenuItems: [],
+  };
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getTrendStart(days: number, now = new Date()): string {
+  const end = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return toDateKey(new Date(end - (days - 1) * 86400000));
+}
+
+function minDate(...dates: string[]): string {
+  return dates.reduce((min, date) => (date < min ? date : min));
+}
+
+function maxDate(...dates: string[]): string {
+  return dates.reduce((max, date) => (date > max ? date : max));
+}
+
+function toRevenueRows(rows: OrderItemQueryRow[]): RevenueRow[] {
+  return rows.map((row) => ({
+    date: row.date,
+    qty: row.qty,
+    unit_price: row.unit_price,
+    order_id: row.order_id,
+    order_status: row.orders?.status ?? "",
+    menu_item_id: row.menu_item_id,
+    menu_item_name: row.menu_items?.name ?? "",
+  }));
+}
+
+export async function getVendorRevenueDashboard(
+  year: number,
+  month: number
+): Promise<VendorRevenueDashboard> {
+  const { user, supabase } = await requireRole("vendor");
+
+  const { data: vendor } = await supabase
+    .from("vendors")
+    .select("id, name")
+    .eq("owner_id", user.id)
+    .single();
+
+  if (!vendor) return emptyDashboard(null);
+
+  const selectedRange = getMonthRange(year, month);
+  const previous = getPreviousMonth(year, month);
+  const previousRange = getMonthRange(previous.year, previous.month);
+  const trendStart = getTrendStart(30);
+  const today = toDateKey(new Date());
+  const start = minDate(previousRange.start, selectedRange.start, trendStart);
+  const end = maxDate(previousRange.end, selectedRange.end, today);
+
+  const { data, error } = await supabase
+    .from("order_items")
+    .select("date, qty, unit_price, order_id, menu_item_id, menu_items!inner(name, vendor_id), orders!inner(status)")
+    .eq("menu_items.vendor_id", vendor.id)
+    .in("orders.status", ["confirmed", "completed"])
+    .gte("date", start)
+    .lte("date", end);
+
+  if (error) return emptyDashboard(vendor);
+
+  const rows = toRevenueRows((data ?? []) as OrderItemQueryRow[]);
+
+  return {
+    vendor,
+    stats: buildRevenueStats(rows, year, month),
+    trend: buildDailyRevenueTrend(rows, 30),
+    topMenuItems: buildTopMenuItems(rows, year, month, 5),
+  };
+}

--- a/app/vendor/revenue/page.tsx
+++ b/app/vendor/revenue/page.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { StatCard } from "@/app/admin/stat-card";
+
+import { getVendorRevenueDashboard } from "./actions";
+import { RevenueBarChart } from "./revenue-bar-chart";
+import { RevenueTrendChart } from "./revenue-trend-chart";
+import { getPreviousMonth, parseRevenueMonth } from "./revenue-model";
+
+type SearchParams = Promise<{
+  year?: string | string[];
+  month?: string | string[];
+}>;
+
+function getNextMonth(year: number, month: number): { year: number; month: number } {
+  if (month === 12) return { year: year + 1, month: 1 };
+  return { year, month: month + 1 };
+}
+
+function monthHref(year: number, month: number): string {
+  return `/vendor/revenue?year=${year}&month=${month}`;
+}
+
+function monthLabel(year: number, month: number): string {
+  return `${year} 年 ${month} 月`;
+}
+
+export default async function VendorRevenuePage({ searchParams }: { searchParams: SearchParams }) {
+  const params = await searchParams;
+  const { year, month } = parseRevenueMonth(params);
+  const previous = getPreviousMonth(year, month);
+  const next = getNextMonth(year, month);
+  const dashboard = await getVendorRevenueDashboard(year, month);
+
+  if (!dashboard.vendor) {
+    return <p className="text-muted-foreground">尚未綁定商家帳號。</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">營業額統計</h1>
+          <p className="text-sm text-muted-foreground">{dashboard.vendor.name} · {monthLabel(year, month)}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link href={monthHref(previous.year, previous.month)}>上個月</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/vendor/revenue">本月</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href={monthHref(next.year, next.month)}>下個月</Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard
+          title="月營收"
+          value={dashboard.stats.thisMonth.revenue}
+          prev={dashboard.stats.lastMonth.revenue}
+          format="currency"
+        />
+        <StatCard
+          title="訂單數"
+          value={dashboard.stats.thisMonth.orders}
+          prev={dashboard.stats.lastMonth.orders}
+          format="number"
+        />
+        <StatCard
+          title="售出份數"
+          value={dashboard.stats.thisMonth.soldQuantity}
+          prev={dashboard.stats.lastMonth.soldQuantity}
+          format="number"
+        />
+        <StatCard
+          title="平均客單"
+          value={
+            dashboard.stats.thisMonth.orders > 0
+              ? dashboard.stats.thisMonth.revenue / dashboard.stats.thisMonth.orders
+              : 0
+          }
+          prev={
+            dashboard.stats.lastMonth.orders > 0
+              ? dashboard.stats.lastMonth.revenue / dashboard.stats.lastMonth.orders
+              : 0
+          }
+          format="currency"
+        />
+      </div>
+
+      <RevenueTrendChart title="近 30 天每日營收" data={dashboard.trend} />
+
+      <RevenueBarChart title={`${monthLabel(year, month)}餐點營收排行`} items={dashboard.topMenuItems} />
+    </div>
+  );
+}

--- a/app/vendor/revenue/revenue-bar-chart.tsx
+++ b/app/vendor/revenue/revenue-bar-chart.tsx
@@ -1,0 +1,33 @@
+import type { MenuRevenueRank } from "./revenue-model";
+
+type Props = {
+  title: string;
+  items: MenuRevenueRank[];
+};
+
+export function RevenueBarChart({ title, items }: Props) {
+  const max = Math.max(...items.map((item) => item.revenue), 1);
+
+  return (
+    <div className="border rounded-lg bg-card p-4 flex flex-col gap-3">
+      <p className="text-sm font-bold">{title}</p>
+      {items.length === 0 && <p className="text-sm text-muted-foreground">暫無資料</p>}
+      {items.map((item) => (
+        <div key={item.name} className="flex flex-col gap-1">
+          <div className="flex justify-between gap-4 text-xs">
+            <span className="truncate max-w-[55%]">{item.name}</span>
+            <span className="text-muted-foreground">
+              {item.count} 份 · ${item.revenue.toLocaleString()}
+            </span>
+          </div>
+          <div className="h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full rounded-full bg-foreground"
+              style={{ width: `${(item.revenue / max) * 100}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/vendor/revenue/revenue-model.test.ts
+++ b/app/vendor/revenue/revenue-model.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDailyRevenueTrend,
+  buildRevenueStats,
+  buildTopMenuItems,
+  getMonthRange,
+  getPreviousMonth,
+  parseRevenueMonth,
+  type RevenueRow,
+} from "@/app/vendor/revenue/revenue-model";
+
+const rows: RevenueRow[] = [
+  {
+    date: "2026-05-31",
+    qty: 2,
+    unit_price: 80,
+    order_id: "may-order",
+    order_status: "confirmed",
+    menu_item_id: "bento",
+    menu_item_name: "雞腿便當",
+  },
+  {
+    date: "2026-06-01",
+    qty: 1,
+    unit_price: 100,
+    order_id: "june-order",
+    order_status: "completed",
+    menu_item_id: "noodle",
+    menu_item_name: "牛肉麵",
+  },
+  {
+    date: "2026-06-10",
+    qty: 3,
+    unit_price: 60,
+    order_id: "cancelled-order",
+    order_status: "cancelled",
+    menu_item_id: "tea",
+    menu_item_name: "紅茶",
+  },
+  {
+    date: "2026-06-12",
+    qty: 2,
+    unit_price: 100,
+    order_id: "pending-order",
+    order_status: "pending",
+    menu_item_id: "noodle",
+    menu_item_name: "牛肉麵",
+  },
+  {
+    date: "2026-06-15",
+    qty: 4,
+    unit_price: 50,
+    order_id: "tea-order",
+    order_status: "confirmed",
+    menu_item_id: "tea",
+    menu_item_name: "紅茶",
+  },
+];
+
+describe("parseRevenueMonth", () => {
+  it("uses valid query string month values", () => {
+    expect(parseRevenueMonth({ year: "2026", month: "5" }, new Date("2026-06-20"))).toEqual({
+      year: 2026,
+      month: 5,
+    });
+  });
+
+  it("falls back to the current month for invalid query values", () => {
+    expect(parseRevenueMonth({ year: "bad", month: "13" }, new Date("2026-06-20"))).toEqual({
+      year: 2026,
+      month: 6,
+    });
+  });
+});
+
+describe("month helpers", () => {
+  it("builds inclusive date boundaries for a month", () => {
+    expect(getMonthRange(2026, 2)).toEqual({
+      start: "2026-02-01",
+      end: "2026-02-28",
+    });
+  });
+
+  it("returns previous month across year boundaries", () => {
+    expect(getPreviousMonth(2026, 1)).toEqual({ year: 2025, month: 12 });
+  });
+});
+
+describe("buildRevenueStats", () => {
+  it("counts revenue by service date and excludes inactive order statuses", () => {
+    const result = buildRevenueStats(rows, 2026, 6);
+
+    expect(result.thisMonth).toEqual({
+      orders: 2,
+      revenue: 300,
+      soldQuantity: 5,
+    });
+    expect(result.lastMonth).toEqual({
+      orders: 1,
+      revenue: 160,
+      soldQuantity: 2,
+    });
+  });
+});
+
+describe("buildDailyRevenueTrend", () => {
+  it("builds a daily revenue series using service dates", () => {
+    const result = buildDailyRevenueTrend(rows, 3, new Date("2026-06-16T12:00:00.000Z"));
+
+    expect(result).toEqual([
+      { date: "2026-06-14", revenue: 0 },
+      { date: "2026-06-15", revenue: 200 },
+      { date: "2026-06-16", revenue: 0 },
+    ]);
+  });
+});
+
+describe("buildTopMenuItems", () => {
+  it("sorts menu items by selected-month revenue", () => {
+    const result = buildTopMenuItems(rows, 2026, 6, 5);
+
+    expect(result).toEqual([
+      { name: "紅茶", count: 4, revenue: 200 },
+      { name: "牛肉麵", count: 1, revenue: 100 },
+    ]);
+  });
+});

--- a/app/vendor/revenue/revenue-model.ts
+++ b/app/vendor/revenue/revenue-model.ts
@@ -1,0 +1,159 @@
+export type RevenueRow = {
+  date: string;
+  qty: number;
+  unit_price: number;
+  order_id: string;
+  order_status: string;
+  menu_item_id: string;
+  menu_item_name: string;
+};
+
+export type RevenueMonth = {
+  year: number;
+  month: number;
+};
+
+export type RevenuePeriodStats = {
+  orders: number;
+  revenue: number;
+  soldQuantity: number;
+};
+
+export type RevenueStats = {
+  thisMonth: RevenuePeriodStats;
+  lastMonth: RevenuePeriodStats;
+};
+
+export type DailyRevenue = {
+  date: string;
+  revenue: number;
+};
+
+export type MenuRevenueRank = {
+  name: string;
+  count: number;
+  revenue: number;
+};
+
+const ACTIVE_STATUSES = new Set(["confirmed", "completed"]);
+
+type SearchParams = {
+  year?: string | string[];
+  month?: string | string[];
+};
+
+function firstValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function dateFromParts(year: number, monthIndex: number, day: number): Date {
+  return new Date(Date.UTC(year, monthIndex, day));
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function isInMonth(date: string, year: number, month: number): boolean {
+  const range = getMonthRange(year, month);
+  return date >= range.start && date <= range.end;
+}
+
+function isActive(row: RevenueRow): boolean {
+  return ACTIVE_STATUSES.has(row.order_status);
+}
+
+export function parseRevenueMonth(params: SearchParams, now = new Date()): RevenueMonth {
+  const year = Number(firstValue(params.year));
+  const month = Number(firstValue(params.month));
+
+  if (Number.isInteger(year) && Number.isInteger(month) && month >= 1 && month <= 12) {
+    return { year, month };
+  }
+
+  return {
+    year: now.getFullYear(),
+    month: now.getMonth() + 1,
+  };
+}
+
+export function getMonthRange(year: number, month: number): { start: string; end: string } {
+  return {
+    start: toDateKey(dateFromParts(year, month - 1, 1)),
+    end: toDateKey(dateFromParts(year, month, 0)),
+  };
+}
+
+export function getPreviousMonth(year: number, month: number): RevenueMonth {
+  if (month === 1) return { year: year - 1, month: 12 };
+  return { year, month: month - 1 };
+}
+
+function buildPeriodStats(rows: RevenueRow[], year: number, month: number): RevenuePeriodStats {
+  const orderIds = new Set<string>();
+  let revenue = 0;
+  let soldQuantity = 0;
+
+  for (const row of rows) {
+    if (!isActive(row) || !isInMonth(row.date, year, month)) continue;
+    orderIds.add(row.order_id);
+    revenue += row.qty * row.unit_price;
+    soldQuantity += row.qty;
+  }
+
+  return {
+    orders: orderIds.size,
+    revenue,
+    soldQuantity,
+  };
+}
+
+export function buildRevenueStats(rows: RevenueRow[], year: number, month: number): RevenueStats {
+  const previous = getPreviousMonth(year, month);
+  return {
+    thisMonth: buildPeriodStats(rows, year, month),
+    lastMonth: buildPeriodStats(rows, previous.year, previous.month),
+  };
+}
+
+export function buildDailyRevenueTrend(
+  rows: RevenueRow[],
+  days: number,
+  now = new Date()
+): DailyRevenue[] {
+  const end = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const totals = new Map<string, number>();
+
+  for (let i = 0; i < days; i++) {
+    const date = toDateKey(new Date(end - (days - 1 - i) * 86400000));
+    totals.set(date, 0);
+  }
+
+  for (const row of rows) {
+    if (!isActive(row) || !totals.has(row.date)) continue;
+    totals.set(row.date, (totals.get(row.date) ?? 0) + row.qty * row.unit_price);
+  }
+
+  return Array.from(totals.entries()).map(([date, revenue]) => ({ date, revenue }));
+}
+
+export function buildTopMenuItems(
+  rows: RevenueRow[],
+  year: number,
+  month: number,
+  limit: number
+): MenuRevenueRank[] {
+  const map = new Map<string, MenuRevenueRank>();
+
+  for (const row of rows) {
+    if (!isActive(row) || !isInMonth(row.date, year, month)) continue;
+    const current = map.get(row.menu_item_id) ?? { name: row.menu_item_name, count: 0, revenue: 0 };
+    current.count += row.qty;
+    current.revenue += row.qty * row.unit_price;
+    map.set(row.menu_item_id, current);
+  }
+
+  return Array.from(map.values())
+    .sort((a, b) => b.revenue - a.revenue)
+    .slice(0, limit);
+}

--- a/app/vendor/revenue/revenue-trend-chart.tsx
+++ b/app/vendor/revenue/revenue-trend-chart.tsx
@@ -1,0 +1,101 @@
+import type { DailyRevenue } from "./revenue-model";
+
+type Props = {
+  title: string;
+  data: DailyRevenue[];
+};
+
+const WIDTH = 600;
+const HEIGHT = 160;
+const PAD = { top: 12, right: 12, bottom: 24, left: 48 };
+
+export function RevenueTrendChart({ title, data }: Props) {
+  const hasRevenue = data.some((item) => item.revenue > 0);
+
+  if (data.length === 0 || !hasRevenue) {
+    return (
+      <div className="border rounded-lg bg-card p-4">
+        <p className="text-sm font-bold mb-2">{title}</p>
+        <p className="text-sm text-muted-foreground">暫無資料</p>
+      </div>
+    );
+  }
+
+  const maxRevenue = Math.max(...data.map((item) => item.revenue), 1);
+  const innerW = WIDTH - PAD.left - PAD.right;
+  const innerH = HEIGHT - PAD.top - PAD.bottom;
+
+  function x(index: number) {
+    return PAD.left + (index / (data.length - 1)) * innerW;
+  }
+
+  function y(revenue: number) {
+    return PAD.top + innerH - (revenue / maxRevenue) * innerH;
+  }
+
+  const points = data.map((item, index) => `${x(index)},${y(item.revenue)}`).join(" ");
+  const gridLines = [0, 0.25, 0.5, 0.75, 1].map((factor) => Math.round(factor * maxRevenue));
+
+  return (
+    <div className="border rounded-lg bg-card p-4 flex flex-col gap-2">
+      <p className="text-sm font-bold">{title}</p>
+      <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="w-full" aria-label={title}>
+        {gridLines.map((value) => (
+          <g key={value}>
+            <line
+              x1={PAD.left}
+              x2={WIDTH - PAD.right}
+              y1={y(value)}
+              y2={y(value)}
+              stroke="currentColor"
+              strokeOpacity={0.1}
+              strokeWidth={1}
+            />
+            <text
+              x={PAD.left - 4}
+              y={y(value)}
+              dominantBaseline="middle"
+              textAnchor="end"
+              fontSize={9}
+              fill="currentColor"
+              fillOpacity={0.5}
+            >
+              ${value.toLocaleString()}
+            </text>
+          </g>
+        ))}
+        <polyline
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+        {data.map((item, index) => (
+          <circle key={item.date} cx={x(index)} cy={y(item.revenue)} r={2.5} fill="currentColor" />
+        ))}
+        <text
+          x={x(0)}
+          y={HEIGHT - 4}
+          fontSize={9}
+          fill="currentColor"
+          fillOpacity={0.5}
+          textAnchor="middle"
+        >
+          {data[0].date.slice(5)}
+        </text>
+        <text
+          x={x(data.length - 1)}
+          y={HEIGHT - 4}
+          fontSize={9}
+          fill="currentColor"
+          fillOpacity={0.5}
+          textAnchor="middle"
+        >
+          {data[data.length - 1].date.slice(5)}
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-05-10-vendor-revenue-stats.md
+++ b/docs/superpowers/plans/2026-05-10-vendor-revenue-stats.md
@@ -1,0 +1,207 @@
+# Vendor Revenue Statistics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a vendor-only revenue statistics page that shows monthly revenue, order count, sold quantity, daily revenue trend, and top menu items.
+
+**Architecture:** Keep the route under `app/vendor/revenue`. Fetch data in server-side helpers guarded by `requireRole("vendor")`, scope all rows through the current user's vendor, and compute view models with pure functions that can be unit tested. Render the page as a Server Component using async `searchParams` and small SVG/CSS chart components.
+
+**Tech Stack:** Next.js 16 App Router, React Server Components, Supabase JS nested selects with `!inner`, Tailwind CSS 4, Vitest.
+
+---
+
+## File Structure
+
+- Create `app/vendor/revenue/revenue-model.ts`
+  - Pure types and functions for date parsing, month ranges, stats aggregation, daily trend aggregation, and menu-item ranking.
+- Create `app/vendor/revenue/revenue-model.test.ts`
+  - Unit tests for the pure revenue logic.
+- Create `app/vendor/revenue/actions.ts`
+  - Server-side data loader guarded by `requireRole("vendor")`.
+- Create `app/vendor/revenue/page.tsx`
+  - Server Component page that reads async `searchParams`, calls the loader, and renders the dashboard.
+- Create `app/vendor/revenue/revenue-trend-chart.tsx`
+  - SVG line chart for daily revenue.
+- Create `app/vendor/revenue/revenue-bar-chart.tsx`
+  - Monthly top-menu revenue bar chart.
+- Modify `app/vendor/layout.tsx`
+  - Add the 「營業額統計」 navigation item.
+
+## Task 1: Revenue Model
+
+**Files:**
+- Create: `app/vendor/revenue/revenue-model.ts`
+- Test: `app/vendor/revenue/revenue-model.test.ts`
+
+- [ ] **Step 1: Write failing model tests**
+
+Cover:
+- Invalid query values fall back to the provided current date.
+- Month range uses `YYYY-MM-DD` boundaries.
+- Revenue uses `date`, not `created_at`.
+- Only `confirmed` and `completed` rows are counted.
+- Top menu items are scoped to rows passed in and sorted by revenue.
+
+Run:
+
+```bash
+bun run test:unit app/vendor/revenue/revenue-model.test.ts
+```
+
+Expected: fail because `revenue-model.ts` does not exist yet.
+
+- [ ] **Step 2: Implement minimal model functions**
+
+Implement:
+- `parseRevenueMonth(searchParams, now)`
+- `getMonthRange(year, month)`
+- `getPreviousMonth(year, month)`
+- `buildRevenueStats(rows, year, month)`
+- `buildDailyRevenueTrend(rows, days, now)`
+- `buildTopMenuItems(rows, year, month, limit)`
+
+Rows should be plain objects with:
+
+```ts
+type RevenueRow = {
+  date: string;
+  qty: number;
+  unit_price: number;
+  order_id: string;
+  order_status: string;
+  menu_item_id: string;
+  menu_item_name: string;
+};
+```
+
+- [ ] **Step 3: Verify model tests pass**
+
+Run:
+
+```bash
+bun run test:unit app/vendor/revenue/revenue-model.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Server Data Loader
+
+**Files:**
+- Create: `app/vendor/revenue/actions.ts`
+
+- [ ] **Step 1: Implement vendor scoped loader**
+
+Create `getVendorRevenueDashboard(year, month)`:
+- Calls `requireRole("vendor")`
+- Reads `vendors.id,name` where `owner_id = user.id`
+- Returns `{ vendor: null, ...empty dashboard }` if not bound
+- Queries `order_items` with:
+
+```ts
+.select("date, qty, unit_price, order_id, menu_item_id, menu_items!inner(name, vendor_id), orders!inner(status)")
+.eq("menu_items.vendor_id", vendor.id)
+.in("orders.status", ["confirmed", "completed"])
+```
+
+Use enough date range to compute selected month, previous month, and near-term trend. Convert Supabase rows into `RevenueRow[]`, then call model functions.
+
+- [ ] **Step 2: Type-check locally**
+
+Run:
+
+```bash
+bunx tsc --noEmit
+```
+
+Expected: no TypeScript errors.
+
+## Task 3: Page UI
+
+**Files:**
+- Create: `app/vendor/revenue/page.tsx`
+- Create: `app/vendor/revenue/revenue-trend-chart.tsx`
+- Create: `app/vendor/revenue/revenue-bar-chart.tsx`
+- Modify: `app/vendor/layout.tsx`
+
+- [ ] **Step 1: Add route and navigation**
+
+Add a fourth vendor nav button:
+
+```tsx
+<Link href="/vendor/revenue">
+  <Button variant="outline" size="sm">營業額統計</Button>
+</Link>
+```
+
+Create the page with:
+
+```ts
+type SearchParams = Promise<{ year?: string | string[]; month?: string | string[] }>;
+```
+
+Await `searchParams`, parse it through `parseRevenueMonth`, and render the dashboard.
+
+- [ ] **Step 2: Add chart components**
+
+Implement simple SVG/CSS components matching existing admin styling:
+- bordered card
+- `bg-card`
+- no chart library
+- empty state text: `暫無資料`
+
+- [ ] **Step 3: Add month links**
+
+Render previous/current/next month links using query string:
+
+```txt
+/vendor/revenue?year=2026&month=5
+```
+
+Keep controls simple and server-rendered.
+
+## Task 4: Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run targeted unit tests**
+
+```bash
+bun run test:unit app/vendor/revenue/revenue-model.test.ts
+```
+
+- [ ] **Step 2: Run lint**
+
+```bash
+bun run lint
+```
+
+- [ ] **Step 3: Run type check**
+
+```bash
+bunx tsc --noEmit
+```
+
+- [ ] **Step 4: Run full unit tests if targeted checks pass**
+
+```bash
+bun run test:unit
+```
+
+## Task 5: Commit
+
+**Files:**
+- Add all implementation and test files from the tasks above.
+
+- [ ] **Step 1: Review diff**
+
+```bash
+git diff -- app/vendor/layout.tsx app/vendor/revenue docs/superpowers/plans/2026-05-10-vendor-revenue-stats.md
+```
+
+- [ ] **Step 2: Commit implementation**
+
+```bash
+git add app/vendor/layout.tsx app/vendor/revenue docs/superpowers/plans/2026-05-10-vendor-revenue-stats.md
+git commit -m "feat(vendor): add revenue statistics dashboard"
+```

--- a/docs/superpowers/specs/2026-05-10-vendor-revenue-stats-design.md
+++ b/docs/superpowers/specs/2026-05-10-vendor-revenue-stats-design.md
@@ -1,0 +1,110 @@
+# 商家營業額統計 — 設計文件
+
+## Goal
+
+在商家後台新增「營業額統計」頁面，讓商家查看自己店家的月營收與銷售表現。這個頁面概念上接近管理員的營運總覽，但資料範圍只限目前登入商家，不顯示其他商家的營收。
+
+## Scope
+
+- 新增商家後台導覽項目：「營業額統計」
+- 新增 `/vendor/revenue` 頁面
+- 以供餐日期 `order_items.date` 歸屬月份，不使用訂單建立時間 `orders.created_at`
+- 只計入有效訂單狀態：`confirmed`、`completed`
+- 排除 `pending`、`cancelled`
+- 顯示本月與上月比較、近 30 天趨勢、本月餐點排行
+- 支援用 query string 切換統計月份，例如 `/vendor/revenue?year=2026&month=5`
+
+## Non-Goals
+
+- 不新增 DB schema 或 migration
+- 不做跨商家排行
+- 不做管理員可見的月結報表變更
+- 不做 CSV 匯出
+- 不處理手續費、平台抽成、退款或稅務欄位
+
+## Data Rules
+
+營收計算來源為 `order_items.qty * order_items.unit_price`。
+
+資料查詢會從目前登入使用者取得 `vendors.owner_id = user.id` 的商家，再查詢該商家底下 `menu_items.vendor_id = vendor.id` 的訂單品項。
+
+月份歸屬使用 `order_items.date`：
+
+- 5 月 30 日下單、6 月 1 日供餐，算 6 月營收
+- 6 月 1 日下單、6 月 3 日供餐，算 6 月營收
+
+訂單狀態規則：
+
+- 計入：`confirmed`、`completed`
+- 不計入：`pending`、`cancelled`
+
+## Page Design
+
+`/vendor/revenue` 是 Server Component 頁面。頁面上方顯示標題與月份切換控制，主體包含三個區塊：
+
+1. 指標卡片
+   - 本月營收
+   - 本月訂單數
+   - 本月售出份數
+   - 營收較上月變化
+
+2. 趨勢圖
+   - 顯示近 30 天每日營收
+   - 使用供餐日期作為 X 軸資料
+   - 沒有資料時顯示「暫無資料」
+
+3. 餐點排行
+   - 顯示選定月份內營收最高的餐點
+   - 每列顯示餐點名稱、售出份數、營收
+   - 排序依營收由高到低
+
+視覺風格沿用管理員後台既有的卡片、細邊框、純 CSS/SVG 圖表，不新增圖表套件。
+
+## Components
+
+新增商家營收專用模組：
+
+- `app/vendor/revenue/page.tsx`
+  - 讀取 query string
+  - 呼叫資料函式
+  - 組合頁面區塊
+
+- `app/vendor/revenue/actions.ts`
+  - `getVendorRevenueStats(year, month)`
+  - `getVendorRevenueTrend(days)`
+  - `getVendorTopMenuItems(year, month, limit)`
+  - 所有函式都會檢查商家角色與商家歸屬
+
+- `app/vendor/revenue/revenue-trend-chart.tsx`
+  - 顯示每日營收折線圖
+
+- `app/vendor/revenue/revenue-bar-chart.tsx`
+  - 顯示餐點營收排行
+
+共用管理員元件可視情況抽出，但優先保持變更範圍小。如果抽共用元件會讓檔案變更過大，商家頁先保留自己的小型圖表元件。
+
+## Access Control
+
+`app/vendor/layout.tsx` 已經檢查使用者是否具有 `vendor` role。營收資料函式仍會再次使用角色檢查，避免只靠 layout 保護。
+
+若使用者沒有綁定商家，頁面顯示：
+
+「尚未綁定商家帳號。」
+
+## Error Handling
+
+- `year` 或 `month` query string 無效時，使用目前年月
+- 沒有營收資料時，數字顯示 0，圖表與排行顯示空狀態
+- 資料查詢失敗時，不顯示其他商家的資料；頁面以空資料降級呈現
+
+## Testing
+
+測試重點：
+
+- 導覽列出現「營業額統計」並連到 `/vendor/revenue`
+- 營收統計只使用 `order_items.date` 篩選月份
+- 只計入 `confirmed`、`completed`
+- 餐點排行只包含目前商家的餐點
+- query string 無效時回到目前年月
+
+優先新增單元測試覆蓋純計算邏輯；頁面整合以現有測試工具能穩定支援的範圍為準。


### PR DESCRIPTION
  ## Summary
  - Add a vendor-only revenue statistics page at `/vendor/revenue`
  - Calculate monthly vendor revenue by `order_items.date` and include only `confirmed` / `completed` orders
  - Add monthly stats, 30-day revenue trend, top menu item ranking, and a vendor dashboard nav entry

  ## Test plan
  - [x] `bun run lint`
  - [x] `bun run test:unit`
  - [x] `bun run test:e2e`