### PR TITLE
fix(security): close addToOrder tampering + lock down RLS / SECURITY DEFINER

### DIFF
--- a/app/menu/[id]/actions.ts
+++ b/app/menu/[id]/actions.ts
@@ -3,22 +3,70 @@
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 
-type SelectedOption = { option_id: string; name: string; price_delta: number };
-
 export async function addToOrder(
   vendorId: string,
   menuItemId: string,
   dailySlotId: string,
   date: string,
-  basePrice: number,
   qty: number,
-  selectedOptions: SelectedOption[] = []
+  optionIds: string[] = []
 ) {
+  if (!Number.isInteger(qty) || qty < 1 || qty > 50) return { error: "數量錯誤" };
+
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: "請先登入" };
 
-  // 找或建立 pending order（用 limit(1) 避免多筆 pending 時 .single() 報錯）
+  // Cross-check slot ↔ menu_item ↔ date (anti-tampering)
+  const { data: slot } = await supabase
+    .from("daily_slots")
+    .select("id, menu_item_id, date")
+    .eq("id", dailySlotId)
+    .single();
+  if (!slot) return { error: "找不到此時段" };
+  if (slot.menu_item_id !== menuItemId || slot.date !== date) {
+    return { error: "時段與餐點不符" };
+  }
+
+  // Fetch authoritative price + verify vendor ownership
+  const { data: menuItem } = await supabase
+    .from("menu_items")
+    .select("id, price, is_available, vendor_id")
+    .eq("id", menuItemId)
+    .single();
+  if (!menuItem || !menuItem.is_available) return { error: "餐點目前未供應" };
+  if (menuItem.vendor_id !== vendorId) return { error: "餐點與商家不符" };
+
+  // Validate options belong to this menu_item, fetch authoritative price_delta + name
+  type ValidatedOption = { id: string; name: string; price_delta: number };
+  let validatedOptions: ValidatedOption[] = [];
+  const uniqueOptionIds = [...new Set(optionIds)];
+  if (uniqueOptionIds.length > 0) {
+    const { data: optionRows } = await supabase
+      .from("item_options")
+      .select("id, name, price_delta, item_option_groups!inner(menu_item_id)")
+      .in("id", uniqueOptionIds);
+    if (!optionRows || optionRows.length !== uniqueOptionIds.length) {
+      return { error: "選項無效" };
+    }
+    for (const r of optionRows) {
+      const group = r.item_option_groups as { menu_item_id: string } | null;
+      if (group?.menu_item_id !== menuItemId) {
+        return { error: "選項不屬於此餐點" };
+      }
+    }
+    validatedOptions = optionRows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      price_delta: r.price_delta,
+    }));
+  }
+
+  const unitPrice =
+    Number(menuItem.price) +
+    validatedOptions.reduce((sum, o) => sum + o.price_delta, 0);
+
+  // Find or create pending order
   let orderId: string;
   const { data: existing } = await supabase
     .from("orders")
@@ -41,8 +89,6 @@ export async function addToOrder(
     orderId = newOrder.id;
   }
 
-  const unitPrice = basePrice + selectedOptions.reduce((sum, o) => sum + o.price_delta, 0);
-
   const { data: orderItem, error } = await supabase
     .from("order_items")
     .insert({
@@ -61,11 +107,11 @@ export async function addToOrder(
     return { error: "加入失敗，請稍後再試" };
   }
 
-  if (selectedOptions.length > 0) {
+  if (validatedOptions.length > 0) {
     await supabase.from("order_item_options").insert(
-      selectedOptions.map((o) => ({
+      validatedOptions.map((o) => ({
         order_item_id: orderItem.id,
-        option_id: o.option_id,
+        option_id: o.id,
         name: o.name,
         price_delta: o.price_delta,
       }))

--- a/app/menu/[id]/add-to-order-dialog.tsx
+++ b/app/menu/[id]/add-to-order-dialog.tsx
@@ -92,16 +92,14 @@ export function AddToOrderDialog({ vendorId, item, slots, optionGroups, children
     if (!slot) return;
     setErrorMsg(null);
 
-    const selected = sortedGroups.flatMap((g) => {
+    const selectedOptionIds = sortedGroups.flatMap((g) => {
       const sel = selections[g.id];
       if (!sel) return [];
-      return g.item_options
-        .filter((o) => sel.has(o.id))
-        .map((o) => ({ option_id: o.id, name: o.name, price_delta: o.price_delta }));
+      return g.item_options.filter((o) => sel.has(o.id)).map((o) => o.id);
     });
 
     startTransition(async () => {
-      const result = await addToOrder(vendorId, item.id, slot.id, date, item.price, Number(qty), selected);
+      const result = await addToOrder(vendorId, item.id, slot.id, date, Number(qty), selectedOptionIds);
       if (result.error) {
         setErrorMsg(result.error);
       } else {

--- a/supabase/migrations/20260526130000_security_hardening.sql
+++ b/supabase/migrations/20260526130000_security_hardening.sql
@@ -1,0 +1,35 @@
+-- Security hardening — three changes:
+--
+-- 1. Tighten profiles_update_own so a user cannot self-promote to admin/vendor
+--    by editing their own role array. The previous policy only checked id =
+--    auth.uid() on USING, with no WITH CHECK, so PostgREST clients could
+--    PATCH role: ['admin'] freely. profiles_update_admin (separate policy)
+--    still lets admins change roles for everyone.
+-- 2. REVOKE EXECUTE on the four SECURITY DEFINER functions from the anon
+--    and authenticated roles so they are no longer reachable via
+--    /rest/v1/rpc/<fn>. RLS policies that reference these functions
+--    continue to work — RLS evaluation is server-side and bypasses the
+--    client EXECUTE permission.
+-- 3. handle_new_user and update_reserved_qty are pure trigger functions;
+--    update_reserved_qty also drives the slot-limiting CHECK. No client
+--    should ever call them as RPC.
+
+-- ====================================================================
+-- 1. profiles_update_own with role-change guard
+-- ====================================================================
+DROP POLICY IF EXISTS "profiles_update_own" ON public.profiles;
+CREATE POLICY "profiles_update_own" ON public.profiles
+  FOR UPDATE
+  USING (id = (SELECT auth.uid()))
+  WITH CHECK (
+    id = (SELECT auth.uid())
+    AND role = (SELECT p.role FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
+  );
+
+-- ====================================================================
+-- 2. REVOKE EXECUTE on SECURITY DEFINER functions from client roles
+-- ====================================================================
+REVOKE EXECUTE ON FUNCTION public.is_admin() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.is_vendor_order(uuid) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_reserved_qty() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM anon, authenticated;


### PR DESCRIPTION
## Summary

Three critical security fixes surfaced by the 2026-05-26 security review.

### App-layer hardening (`app/menu/[id]/actions.ts`)

1. **Price tampering closed** — `addToOrder` no longer trusts `basePrice` / `price_delta` from the client. The server re-fetches the authoritative price from `menu_items` + `item_options` and computes `unit_price` itself.
2. **Slot ↔ menu_item ↔ date cross-check** — the server now looks up `daily_slots` by id and verifies `menu_item_id` and `date` match before inserting, so an attacker can't pair A's slot with B's menu item to bypass the oversell `CHECK`.
3. **Option ownership validation** — every `optionId` is joined back through `item_option_groups.menu_item_id` and rejected if it doesn't belong to the chosen menu item.

Also: `qty ∈ [1, 50]` integer guard, `optionIds` deduped, `menu_item.is_available` re-checked server-side. Caller signature changed; `add-to-order-dialog.tsx` updated.

### DB hardening (`20260526130000_security_hardening.sql`)

- **`profiles_update_own` WITH CHECK pins `role`** — previously had only `USING`, so a logged-in user could `PATCH /rest/v1/profiles?id=eq.<self> { role: ['admin'] }` and grant themselves admin. New `WITH CHECK` clause requires `role` to equal the current value. `profiles_update_admin` (separate policy) still lets admins change roles for anyone.
- **`REVOKE EXECUTE` on 4 SECURITY DEFINER functions from `anon`/`authenticated`**:
  - `is_admin()`, `is_vendor_order(uuid)` — used internally by RLS policies; RLS evaluation is server-side and doesn't need client EXECUTE.
  - `update_reserved_qty()`, `handle_new_user()` — pure trigger functions; never meant to be RPC-callable.

Addresses 8 of the 11 Supabase advisor security WARNs.

## Risk / rollback

- **Migration is reversible** — `GRANT EXECUTE ...` to restore RPC access if anything breaks; old policy can be restored from the diff.
- **App change is backward-incompatible at the function signature level** — `addToOrder` parameters changed. Only `add-to-order-dialog.tsx` calls it; updated in the same commit.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` (compile + TypeScript) green
- [ ] CI lint + build
- [ ] After merge: apply migration via `mcp__supabase-cnd__apply_migration`, then sanity-check `/menu/<vendor>` add-to-cart still works (a user that owns the role grant) and `/admin/users` role grant still works (admin path).

## Out of scope (next PR)

- Storage policy ownership check (touches existing image URLs in production — separate migration after we settle on path scheme).
- Bucket SELECT policy narrowing (advisor WARN — low priority since URL access doesn't depend on it).
- Mock-based tests for `addToOrder` / `requireRole` / pickup (next PR — task #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)