### PR TITLE
test+ci: critical-path tests for addToOrder / requireRole / pickup + unit gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Unit tests
+        run: bun run test:unit
+
       - name: Build
         run: bun run build
         env:

--- a/app/menu/[id]/actions.test.ts
+++ b/app/menu/[id]/actions.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+import { addToOrder } from "@/app/menu/[id]/actions";
+
+type QueryResult = { data?: unknown; error?: unknown };
+type FromExpectation = { table: string; result: QueryResult };
+
+function createSupabaseMock({
+  user,
+  expectations,
+}: {
+  user: { id: string } | null;
+  expectations: FromExpectation[];
+}) {
+  const queue = [...expectations];
+  const insertCaptures: Record<string, unknown[]> = {};
+
+  function makeBuilder(result: QueryResult, table: string) {
+    const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+    const passthrough = ["select", "eq", "in", "order", "limit"] as const;
+    for (const m of passthrough) builder[m] = vi.fn(() => builder as never);
+    builder.insert = vi.fn((payload: unknown) => {
+      (insertCaptures[table] ??= []).push(payload);
+      return builder as never;
+    });
+    builder.update = vi.fn(() => builder as never);
+    builder.delete = vi.fn(() => builder as never);
+    builder.single = vi.fn(async () => result);
+    builder.maybeSingle = vi.fn(async () => result);
+    // Thenable so `await query.in(...)` resolves to result.
+    (builder as unknown as { then: (resolve: (v: QueryResult) => void) => Promise<void> }).then = (
+      resolve
+    ) => Promise.resolve(result).then(resolve);
+    return builder;
+  }
+
+  return {
+    insertCaptures,
+    client: {
+      auth: { getUser: vi.fn(async () => ({ data: { user } })) },
+      from: vi.fn((table: string) => {
+        const exp = queue.shift();
+        if (!exp) throw new Error(`Unexpected from(${table}) — queue empty`);
+        if (exp.table !== table) {
+          throw new Error(`Expected from(${exp.table}), got from(${table})`);
+        }
+        return makeBuilder(exp.result, table);
+      }),
+    },
+  };
+}
+
+describe("addToOrder", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+  });
+
+  it("rejects when the user is not logged in", async () => {
+    const { client } = createSupabaseMock({ user: null, expectations: [] });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "請先登入" });
+  });
+
+  it("rejects qty out of bounds without touching the DB", async () => {
+    const { client } = createSupabaseMock({ user: { id: "u1" }, expectations: [] });
+    createClientMock.mockResolvedValue(client);
+
+    const negative = await addToOrder("v1", "m1", "s1", "2026-05-27", 0, []);
+    expect(negative).toEqual({ error: "數量錯誤" });
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the daily_slot does not belong to the menu_item (anti-tampering)", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "OTHER", date: "2026-05-27" } },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "時段與餐點不符" });
+  });
+
+  it("rejects when the menu_item does not belong to the vendor (anti-tampering)", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "OTHER_VENDOR" },
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "餐點與商家不符" });
+  });
+
+  it("computes unit_price from server-fetched price + option deltas, ignoring any client-side number", async () => {
+    const { client, insertCaptures } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "v1" },
+          },
+        },
+        {
+          table: "item_options",
+          result: {
+            data: [
+              {
+                id: "o1",
+                name: "加蛋",
+                price_delta: 15,
+                item_option_groups: { menu_item_id: "m1" },
+              },
+            ],
+          },
+        },
+        // No pending order yet
+        { table: "orders", result: { data: null } },
+        // Insert new order
+        { table: "orders", result: { data: { id: "ord1" } } },
+        // Insert order_item
+        { table: "order_items", result: { data: { id: "oi1" }, error: null } },
+        // Insert order_item_options (fire-and-forget but mock still consumed)
+        { table: "order_item_options", result: { data: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 2, ["o1"]);
+    expect(result).toEqual({ success: true });
+
+    // Server computed unit_price = 100 + 15 = 115
+    expect(insertCaptures.order_items?.[0]).toMatchObject({
+      menu_item_id: "m1",
+      daily_slot_id: "s1",
+      qty: 2,
+      unit_price: 115,
+    });
+  });
+
+  it("rejects when an option does not belong to the chosen menu_item", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "v1" },
+          },
+        },
+        {
+          table: "item_options",
+          result: {
+            data: [
+              {
+                id: "o1",
+                name: "加蛋",
+                price_delta: 15,
+                item_option_groups: { menu_item_id: "DIFFERENT_MENU" },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, ["o1"]);
+    expect(result).toEqual({ error: "選項不屬於此餐點" });
+  });
+
+  it("translates Postgres CHECK violation (23514) to 此日期已售完", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "v1" },
+          },
+        },
+        { table: "orders", result: { data: { id: "ord1" } } }, // existing pending order
+        {
+          table: "order_items",
+          result: { data: null, error: { code: "23514" } },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "此日期已售完" });
+  });
+});

--- a/app/vendor/orders/actions.test.ts
+++ b/app/vendor/orders/actions.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+import { pickUpOrderItem } from "@/app/vendor/orders/actions";
+
+type QueryResult = { data?: unknown; error?: unknown };
+type FromExpectation = { table: string; result: QueryResult };
+
+function createSupabaseMock({
+  user,
+  expectations,
+}: {
+  user: { id: string } | null;
+  expectations: FromExpectation[];
+}) {
+  const queue = [...expectations];
+  const updateCaptures: Array<{ table: string; payload: unknown }> = [];
+
+  function makeBuilder(result: QueryResult, table: string) {
+    const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+    const passthrough = ["select", "eq", "in", "order", "limit"] as const;
+    for (const m of passthrough) builder[m] = vi.fn(() => builder as never);
+    builder.update = vi.fn((payload: unknown) => {
+      updateCaptures.push({ table, payload });
+      return builder as never;
+    });
+    builder.insert = vi.fn(() => builder as never);
+    builder.delete = vi.fn(() => builder as never);
+    builder.single = vi.fn(async () => result);
+    builder.maybeSingle = vi.fn(async () => result);
+    (builder as unknown as { then: (resolve: (v: QueryResult) => void) => Promise<void> }).then = (
+      resolve
+    ) => Promise.resolve(result).then(resolve);
+    return builder;
+  }
+
+  return {
+    updateCaptures,
+    client: {
+      auth: { getUser: vi.fn(async () => ({ data: { user } })) },
+      from: vi.fn((table: string) => {
+        const exp = queue.shift();
+        if (!exp) throw new Error(`Unexpected from(${table}) — queue empty`);
+        if (exp.table !== table) {
+          throw new Error(`Expected from(${exp.table}), got from(${table})`);
+        }
+        return makeBuilder(exp.result, table);
+      }),
+    },
+  };
+}
+
+describe("pickUpOrderItem", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+  });
+
+  it("rejects when the user is not logged in", async () => {
+    const { client } = createSupabaseMock({ user: null, expectations: [] });
+    createClientMock.mockResolvedValue(client);
+    const result = await pickUpOrderItem("oi1");
+    expect(result).toEqual({ error: "請先登入" });
+  });
+
+  it("rejects when the user has no vendor record", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [{ table: "vendors", result: { data: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+    const result = await pickUpOrderItem("oi1");
+    expect(result).toEqual({ error: "找不到商家帳號" });
+  });
+
+  it("rejects when the item belongs to a different vendor (boundary)", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              order_id: "ord1",
+              menu_items: { vendor_id: "OTHER_VENDOR" },
+            },
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+    const result = await pickUpOrderItem("oi1");
+    expect(result).toEqual({ error: "此品項不屬於您" });
+  });
+
+  it("marks the order completed when the last item is picked up", async () => {
+    const { client, updateCaptures } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              order_id: "ord1",
+              menu_items: { vendor_id: "v1" },
+            },
+          },
+        },
+        { table: "order_items", result: { data: null, error: null } }, // update picked_up=true
+        { table: "order_items", result: { data: [] } }, // remaining unpicked = empty
+        { table: "orders", result: { data: null, error: null } }, // update status=completed
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+    const result = await pickUpOrderItem("oi1");
+    expect(result).toEqual({ success: true, order_id: "ord1" });
+    expect(updateCaptures).toEqual([
+      { table: "order_items", payload: { picked_up: true } },
+      { table: "orders", payload: { status: "completed" } },
+    ]);
+  });
+
+  it("does NOT mark the order completed when other items remain unpicked", async () => {
+    const { client, updateCaptures } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: { id: "oi1", order_id: "ord1", menu_items: { vendor_id: "v1" } },
+          },
+        },
+        { table: "order_items", result: { data: null, error: null } }, // update
+        { table: "order_items", result: { data: [{ id: "oi2" }] } }, // remaining
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+    const result = await pickUpOrderItem("oi1");
+    expect(result).toEqual({ success: true, order_id: "ord1" });
+    expect(updateCaptures).toEqual([
+      { table: "order_items", payload: { picked_up: true } },
+    ]);
+  });
+});

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+import { requireRole } from "@/lib/auth";
+
+function mockSupabase({ user, role }: { user: { id: string } | null; role: string[] | null }) {
+  const single = vi.fn(async () => ({ data: role === null ? null : { role } }));
+  const eq = vi.fn(() => ({ single }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  return {
+    auth: { getUser: vi.fn(async () => ({ data: { user } })) },
+    from,
+    _spies: { single, eq, select, from },
+  };
+}
+
+describe("requireRole", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+  });
+
+  it("throws when there is no logged-in user", async () => {
+    const supabase = mockSupabase({ user: null, role: null });
+    createClientMock.mockResolvedValue(supabase);
+    await expect(requireRole("admin")).rejects.toThrow("未登入");
+  });
+
+  it("throws when the profile is missing", async () => {
+    const supabase = mockSupabase({ user: { id: "u1" }, role: null });
+    createClientMock.mockResolvedValue(supabase);
+    await expect(requireRole("vendor")).rejects.toThrow("權限不足");
+  });
+
+  it("throws when the role array does not include the required role", async () => {
+    const supabase = mockSupabase({ user: { id: "u1" }, role: ["user"] });
+    createClientMock.mockResolvedValue(supabase);
+    await expect(requireRole("admin")).rejects.toThrow("權限不足");
+  });
+
+  it("returns the user + supabase when the role is granted", async () => {
+    const supabase = mockSupabase({ user: { id: "u1" }, role: ["user", "vendor"] });
+    createClientMock.mockResolvedValue(supabase);
+    const result = await requireRole("vendor");
+    expect(result.user.id).toBe("u1");
+    expect(result.supabase).toBe(supabase);
+  });
+
+  it("matches one role out of a multi-role array (admin grant)", async () => {
+    const supabase = mockSupabase({ user: { id: "u1" }, role: ["vendor", "admin"] });
+    createClientMock.mockResolvedValue(supabase);
+    await expect(requireRole("admin")).resolves.toMatchObject({ user: { id: "u1" } });
+  });
+});


### PR DESCRIPTION
## Summary

Closes two Critical findings from the 2026-05-26 testing review:

1. **Critical-path Server Actions had zero tests** — `addToOrder` (slot CHECK + price tampering + boundary checks), `requireRole` (auth single entrypoint), `pickUpOrderItem` (vendor cross-tenant + auto-complete).
2. **CI did not gate unit tests** — the existing 25 cases were not running on PRs.

## What this PR adds

- `lib/auth.test.ts` (5 cases) — unauth / missing profile / role mismatch / single grant / multi-role grant.
- `app/menu/[id]/actions.test.ts` (7 cases) — unauth, `qty=0`, slot↔menu_item mismatch, menu_item↔vendor mismatch, **server-computed `unit_price` with options** (proves the client can't tamper basePrice), option↔menu ownership check, `23514` → `此日期已售完` translation.
- `app/vendor/orders/actions.test.ts` (5 cases) — unauth, no vendor account, cross-vendor item rejection, auto-complete order when last item picked, no auto-complete when items remain.
- `.github/workflows/ci.yml` — new `bun run test:unit` step between lint and build.

## Numbers

- Total unit tests: **25 → 42** (+17, +68%).
- Critical-path coverage: 0 → covered for the three actions called out by the testing review.
- CI gate: lint + **test:unit** + build (was lint + build).

## Test plan

- [x] `bun run test:unit` green locally (42/42 pass).
- [x] `bun run build` green.
- [ ] CI lint + test:unit + build all green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)