### PR TITLE
refactor(header): drop redundant vendor dashboard / order catalog buttons

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -37,16 +37,6 @@ export async function Header() {
         <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />
       </div>
       <div className="flex items-center gap-4">
-        {navigation.showVendorDashboard && (
-          <Link href="/vendor">
-            <Button variant="outline" size="sm">商家後台</Button>
-          </Link>
-        )}
-        {navigation.showOrderCatalog && (
-          <Link href="/">
-            <Button variant="outline" size="sm">點餐目錄</Button>
-          </Link>
-        )}
         {navigation.showAdminDashboard && (
           <Link href="/admin">
             <Button variant="outline" size="sm">管理後台</Button>

--- a/lib/navigation-rules.test.ts
+++ b/lib/navigation-rules.test.ts
@@ -22,27 +22,11 @@ describe("navigation rules", () => {
     expect(getDefaultHomePath(["vendor", "admin", "user"])).toBe("/admin");
   });
 
-  it("shows 點餐目錄 for vendor and admin accounts", () => {
-    expect(getHeaderNavigation(["user"])).toMatchObject({
-      showOrderCatalog: false,
-      showVendorDashboard: false,
-      showAdminDashboard: false,
-    });
-    expect(getHeaderNavigation(["admin"])).toMatchObject({
-      showOrderCatalog: true,
-      showVendorDashboard: false,
-      showAdminDashboard: true,
-    });
-    expect(getHeaderNavigation(["vendor"])).toMatchObject({
-      showOrderCatalog: true,
-      showVendorDashboard: true,
-      showAdminDashboard: false,
-    });
-    expect(getHeaderNavigation(["vendor", "admin"])).toMatchObject({
-      showOrderCatalog: true,
-      showVendorDashboard: true,
-      showAdminDashboard: true,
-    });
+  it("only shows admin dashboard button for admin accounts", () => {
+    expect(getHeaderNavigation(["user"])).toMatchObject({ showAdminDashboard: false });
+    expect(getHeaderNavigation(["vendor"])).toMatchObject({ showAdminDashboard: false });
+    expect(getHeaderNavigation(["admin"])).toMatchObject({ showAdminDashboard: true });
+    expect(getHeaderNavigation(["vendor", "admin"])).toMatchObject({ showAdminDashboard: true });
   });
 
   it("keeps cart and orders visible for all logged-in roles", () => {

--- a/lib/navigation-rules.ts
+++ b/lib/navigation-rules.ts
@@ -5,13 +5,10 @@ export function getDefaultHomePath(roles: string[]) {
 }
 
 export function getHeaderNavigation(roles: string[]) {
-  const isVendor = roles.includes("vendor");
   const isAdmin = roles.includes("admin");
 
   return {
-    showVendorDashboard: isVendor,
     showAdminDashboard: isAdmin,
-    showOrderCatalog: isVendor || isAdmin,
     showCart: true,
     showOrders: true,
   };


### PR DESCRIPTION
## Summary

- Login flow already routes `vendor` → `/vendor` and regular users → `/` via `getDefaultHomePath` (used by both `proxy.ts` and `app/login/actions.ts`), so the two header buttons were unreachable code paths in normal use — a single account never sees both views as a useful pair.
- Remove the 商家後台 / 點餐目錄 buttons from `components/header.tsx` and drop the now-unused `showVendorDashboard` / `showOrderCatalog` flags from `lib/navigation-rules.ts`. Admin dashboard button stays (admins are dual-role and may explicitly toggle).
- Tests updated to reflect the trimmed shape; 6/6 pass.

## Test plan

- [x] `bun run vitest run lib/navigation-rules.test.ts` — 6/6 green
- [ ] Manual: log in as vendor → land on `/vendor`, header has no extra nav button
- [ ] Manual: log in as user → land on `/`, header unchanged
- [ ] Manual: log in as admin → land on `/admin`, 管理後台 button still present