### PR TITLE
style(home): remove max-width cap, switch page background to pure white

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,7 +102,7 @@
 }
 
 :root {
-  --background: oklch(0.97 0 0);
+  --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -136,7 +136,7 @@
   --sidebar-ring: oklch(0.708 0 0);
 
   /* Design system — surface hierarchy (light) */
-  --surface-canvas: oklch(0.97 0 0);
+  --surface-canvas: oklch(1 0 0);
   --surface-card: oklch(1 0 0);
   --surface-placeholder: oklch(0.92 0 0);
   --surface-loader: oklch(0.85 0 0);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,7 +47,7 @@ export default async function HomePage({ searchParams }: Props) {
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-8">
+      <div className="w-full p-4 flex flex-col gap-8">
         {(trending.length > 0 || nutritionPicks.length > 0 || randomPicks.length > 0) && (
           <div className="flex flex-col gap-6">
             {trending.length > 0 && <RecommendationSection title="🔥 熱銷排行" items={trending} accent />}


### PR DESCRIPTION
## Summary

- `app/page.tsx`: drop the `max-w-6xl` container so the homepage spans the full viewport on large screens.
- `app/globals.css`: light-theme `--background` and `--surface-canvas` go from `oklch(0.97)` to `oklch(1)`. Both tokens describe the page canvas, so they move together. The muted/secondary/accent affordance tokens (also at 0.97) stay — they need that contrast against the canvas. Dark mode untouched.

## Test plan

- [x] `bun run vitest run` — 42/42 green
- [ ] Manual: home (`/`) — pure white background, vendor grid uses the full viewport width
- [ ] Manual: `/vendor`, `/admin`, `/menu/[id]`, `/cart`, `/orders`, `/profile` — background also white, no hover/muted regressions
- [ ] Manual: toggle dark mode — unchanged