### PR TITLE
feat(header): add light/dark theme toggle

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import { AreaSelect } from "./area-select";
+import { ThemeToggle } from "./theme-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { getHeaderNavigation } from "@/lib/navigation-rules";
@@ -42,6 +43,7 @@ export async function Header() {
             <Button variant="outline" size="sm">管理後台</Button>
           </Link>
         )}
+        <ThemeToggle />
         {navigation.showOrders && (
           <Link href="/orders">
             <Button variant="outline">

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <Button
+      variant="outline"
+      aria-label="切換主題"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="size-4 hidden dark:block" />
+      <Moon className="size-4 dark:hidden" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

- New client component `components/theme-toggle.tsx` — sun / moon icon button using `next-themes`. Toggles based on `resolvedTheme` so it does the right thing when the user is on the system preference.
- Hooked into `components/header.tsx` next to the admin shortcut, before orders / cart, so all icon-only buttons sit together.
- Both icons are always rendered; CSS (`dark:` variant) controls visibility. Avoids the mounted-state hydration dance and the new `react-hooks/set-state-in-effect` lint that the standard pattern trips.

## Test plan

- [x] `bun run vitest run` — 42/42 green
- [x] `bunx eslint components/theme-toggle.tsx components/header.tsx` — clean
- [ ] Manual: click toggle → background flips between light and dark, header / cards reflect the new theme
- [ ] Manual: reload page after switching → preference persisted (next-themes default localStorage)