### PR TITLE
feat(home): per-item grid + carousel-as-anchors

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -4,10 +4,10 @@ export default function HomeLoading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
       <div className="max-w-6xl w-full p-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {Array.from({ length: 6 }).map((_, i) => (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
             <div key={i} className="flex flex-col gap-3">
-              <Skeleton className="aspect-video w-full rounded-lg" />
+              <Skeleton className="aspect-square w-full rounded-card" />
               <Skeleton className="h-4 w-3/4" />
               <Skeleton className="h-3 w-1/2" />
             </div>

--- a/app/menu/[id]/page.tsx
+++ b/app/menu/[id]/page.tsx
@@ -81,14 +81,16 @@ export default async function MenuPage({ params }: Props) {
             const hasAvailable = slots.some((s) => s.max_qty - s.reserved_qty > 0);
 
             return (
-              <AddToOrderDialog key={item.id} vendorId={vendor.id} item={item} slots={slots} optionGroups={item.item_option_groups} disabled={!hasAvailable}>
-                <MenuItemCard
-                  item={item}
-                  status={!hasAvailable && (
-                    <p className="text-sm text-destructive">本週已售完</p>
-                  )}
-                />
-              </AddToOrderDialog>
+              <div key={item.id} id={`item-${item.id}`} className="scroll-mt-20">
+                <AddToOrderDialog vendorId={vendor.id} item={item} slots={slots} optionGroups={item.item_option_groups} disabled={!hasAvailable}>
+                  <MenuItemCard
+                    item={item}
+                    status={!hasAvailable && (
+                      <p className="text-sm text-destructive">本週已售完</p>
+                    )}
+                  />
+                </AddToOrderDialog>
+              </div>
             );
           })}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,12 @@
-import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { HomeItemCard } from "@/components/home-item-card";
 import RecommendationSection from "@/components/recommendation-section";
-import { getTrendingItems, getNutritionPicks, getRandomPicks } from "@/lib/recommendation";
+import {
+  getHomeItems,
+  getNutritionPicks,
+  getRandomPicks,
+  getTrendingItems,
+} from "@/lib/recommendation";
 import { createClient } from "@/lib/supabase/server";
-import { HeartIcon } from "lucide-react";
-import Image from "next/image";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 interface Props {
@@ -15,7 +17,9 @@ export default async function HomePage({ searchParams }: Props) {
   const { area } = await searchParams;
   const supabase = await createClient();
 
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (!area) {
     if (user) {
@@ -28,79 +32,46 @@ export default async function HomePage({ searchParams }: Props) {
     }
   }
 
-  // 撈該區域的商家（透過 vendor_areas 關聯）
-  let query = supabase
-    .from("vendors")
-    .select("id, name, description, tags, image_url, rating_good, rating_bad, is_open, vendor_areas!inner(area_id)")
-    .eq("is_active", true);
-
-  if (area) {
-    query = query.eq("vendor_areas.area_id", area);
-  }
-
-  const [{ data: vendors }, trending, nutritionPicks, randomPicks] = await Promise.all([
-    query.order("name"),
+  const [items, trending, nutritionPicks, randomPicks] = await Promise.all([
+    getHomeItems(area),
     getTrendingItems(8, area),
     getNutritionPicks(8, area),
     getRandomPicks(user?.id ?? null, 8, area),
   ]);
 
+  const hasCarousels = trending.length + nutritionPicks.length + randomPicks.length > 0;
+
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="w-full p-4 flex flex-col gap-8">
-        {(trending.length > 0 || nutritionPicks.length > 0 || randomPicks.length > 0) && (
+      <div className="w-full max-w-6xl p-4 flex flex-col gap-8">
+        {hasCarousels && (
           <div className="flex flex-col gap-6">
-            {trending.length > 0 && <RecommendationSection title="🔥 熱銷排行" items={trending} accent />}
-            {nutritionPicks.length > 0 && <RecommendationSection title="💪 營養推薦" items={nutritionPicks} />}
-            {randomPicks.length > 0 && <RecommendationSection title="🎲 隨機探索" items={randomPicks} />}
+            {trending.length > 0 && (
+              <RecommendationSection title="🔥 熱銷排行" items={trending} accent />
+            )}
+            {nutritionPicks.length > 0 && (
+              <RecommendationSection title="💪 營養推薦" items={nutritionPicks} />
+            )}
+            {randomPicks.length > 0 && (
+              <RecommendationSection title="🎲 隨機探索" items={randomPicks} />
+            )}
           </div>
         )}
-        {vendors && vendors.length === 0 && (
-          <p className="text-muted-foreground text-center py-16">
-            {area ? "此校區目前沒有合作商家" : "請先選擇校區"}
-          </p>
-        )}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {(vendors ?? []).map((vendor) => {
-            const total = vendor.rating_good + vendor.rating_bad;
-            const rating = total > 0
-              ? ((vendor.rating_good / total) * 5).toFixed(1)
-              : null;
 
-            return (
-              <Link key={vendor.id} href={`/menu/${vendor.id}`}>
-                <div className="hover:scale-[1.02] transition-all duration-200 w-full flex flex-col gap-3">
-                  <AspectRatio className="bg-surface-placeholder rounded-card overflow-hidden" ratio={16 / 9}>
-                    {vendor.image_url && (
-                      <Image src={vendor.image_url} alt={vendor.name} fill sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw" className="object-cover" priority />
-                    )}
-                  </AspectRatio>
-                  <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <p className="text-heading-sm font-semibold">{vendor.name}</p>
-                      {!vendor.is_open && (
-                        <span className="text-caption text-muted-foreground border rounded-pill px-2 py-0.5">暫停營業</span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 flex-wrap">
-                      {rating && (
-                        <span className="text-meta text-muted-foreground flex items-center gap-1">
-                          <HeartIcon className="size-3" />
-                          {rating} ({total})
-                        </span>
-                      )}
-                      {vendor.tags.map((tag) => (
-                        <span key={tag} className="text-caption text-muted-foreground border rounded-pill px-2 py-0.5">
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
+        {items.length === 0 ? (
+          <p className="text-muted-foreground text-center py-16">
+            {area ? "此校區目前沒有可預訂的餐點" : "請先選擇校區"}
+          </p>
+        ) : (
+          <section className="flex flex-col gap-3">
+            <h2 className="text-heading font-semibold">所有餐點</h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              {items.map((item) => (
+                <HomeItemCard key={item.id} item={item} />
+              ))}
+            </div>
+          </section>
+        )}
       </div>
     </main>
   );

--- a/components/home-item-card.tsx
+++ b/components/home-item-card.tsx
@@ -1,0 +1,62 @@
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import type { HomeItem } from "@/lib/recommendation";
+import Image from "next/image";
+import Link from "next/link";
+
+interface Props {
+  item: HomeItem;
+}
+
+export function HomeItemCard({ item }: Props) {
+  return (
+    <Link
+      href={`/menu/${item.vendor_id}#item-${item.id}`}
+      className="group flex flex-col gap-3 hover:scale-[1.02] transition-all duration-200"
+    >
+      <AspectRatio
+        ratio={1}
+        className="bg-surface-placeholder rounded-card overflow-hidden relative"
+      >
+        {item.image_url && (
+          <Image
+            src={item.image_url}
+            alt={item.name}
+            fill
+            sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            className="object-cover"
+          />
+        )}
+        {!item.vendor_is_open && (
+          <span className="absolute top-2 left-2 text-caption font-semibold rounded-badge bg-card/90 px-2 py-1 text-muted-foreground">
+            暫停營業
+          </span>
+        )}
+      </AspectRatio>
+      <div className="flex flex-col gap-1 px-1">
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-heading-sm font-semibold leading-tight line-clamp-2">{item.name}</p>
+          <p className="text-body-strong shrink-0">${item.price}</p>
+        </div>
+        <p className="text-meta text-muted-foreground truncate">{item.vendor_name}</p>
+        {(item.calories || item.protein) && (
+          <div className="flex flex-wrap gap-x-2 text-caption text-muted-foreground">
+            {item.calories && <span>{item.calories} kcal</span>}
+            {item.protein && <span>蛋白 {item.protein}g</span>}
+          </div>
+        )}
+        {item.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {item.tags.slice(0, 3).map((tag) => (
+              <span
+                key={tag}
+                className="text-caption border rounded-pill px-2 py-0.5 text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -12,6 +12,63 @@ export type RecommendedItem = {
   vendor_name: string;
 };
 
+export type HomeItem = {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number;
+  image_url: string | null;
+  tags: string[];
+  calories: number | null;
+  protein: number | null;
+  sodium: number | null;
+  vendor_id: string;
+  vendor_name: string;
+  vendor_is_open: boolean;
+};
+
+export async function getHomeItems(areaId?: string, limit = 60): Promise<HomeItem[]> {
+  const supabase = await createClient();
+
+  const select = areaId
+    ? "id, name, description, price, image_url, tags, calories, protein, sodium, vendor_id, vendors!inner(id, name, is_active, is_open, vendor_areas!inner(area_id))"
+    : "id, name, description, price, image_url, tags, calories, protein, sodium, vendor_id, vendors!inner(id, name, is_active, is_open)";
+
+  let query = supabase
+    .from("menu_items")
+    .select(select)
+    .eq("is_available", true)
+    .eq("vendors.is_active", true);
+
+  if (areaId) query = query.eq("vendors.vendor_areas.area_id", areaId);
+
+  const { data: items } = await query.limit(limit);
+  if (!items) return [];
+
+  return items
+    .map((item) => {
+      const vendor = item.vendors as { name: string; is_open: boolean } | null;
+      return {
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        price: item.price,
+        image_url: item.image_url,
+        tags: item.tags ?? [],
+        calories: item.calories,
+        protein: item.protein,
+        sodium: item.sodium,
+        vendor_id: item.vendor_id,
+        vendor_name: vendor?.name ?? "",
+        vendor_is_open: vendor?.is_open ?? false,
+      };
+    })
+    .sort((a, b) => {
+      if (a.vendor_is_open !== b.vendor_is_open) return a.vendor_is_open ? -1 : 1;
+      return a.name.localeCompare(b.name, "zh-Hant");
+    });
+}
+
 export async function getTrendingItems(limit = 8, areaId?: string): Promise<RecommendedItem[]> {
   const supabase = await createClient();
   const since = new Date(new Date().getTime() - 7 * 86400000).toISOString();


### PR DESCRIPTION
## Summary
- 首頁從 per-vendor grid 改成 per-item grid（2/3/4 cols 響應式，photography-first 1:1 卡片）
- 推薦 carousels (trending / nutrition / random) 保留作為 discovery anchors，主 grid 改為「所有餐點」
- 點 item card → `/menu/<vendor>#item-<id>`，vendor 頁面加 id 錨點支援 deep link
- HomeItem 型別 + `getHomeItems(areaId)` 新 query helper，join vendors + vendor_areas 過濾

純前端 + query refactor，無 DB schema 變更。

## Test plan
- [ ] `/` 在已登入狀態下顯示用戶廠區的所有可訂購餐點 grid（依 vendor.is_open + name 排序）
- [ ] `/?area=<id>` 切換廠區後 grid 正確過濾
- [ ] 暫停營業商家的餐點仍顯示但有「暫停營業」angle badge
- [ ] 點任一卡片跳到 `/menu/<vendor>#item-<id>`，捲動定位到該餐點
- [ ] Mobile (2 cols) 與 desktop (4 cols) 排版正常
- [ ] 三組推薦 carousel 仍然顯示

是 P1 of 4-phase recommendation overhaul（P2 AI tags、P3 personalised ranking、P4 semantic search 接續）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)