### PR TITLE
feat(ai): controlled-vocab tag pipeline + nutrition auto-fill

### DIFF
--- a/app/vendor/menu/actions.ts
+++ b/app/vendor/menu/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { requireRole } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 
 async function requireVendor() {
   const { user, supabase } = await requireRole("vendor");
@@ -13,6 +14,21 @@ async function requireVendor() {
     .single();
   if (!vendor) throw new Error("找不到商家");
   return { supabase, vendor };
+}
+
+async function invokeAiTagGeneration(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  menuItemIds: string[],
+  force = false,
+) {
+  if (menuItemIds.length === 0) return { error: "no items" };
+  const { data, error } = await supabase.functions.invoke<{
+    results: Array<{ id: string; status: string; error?: string }>;
+  }>("generate-menu-item-tags", {
+    body: { menu_item_ids: menuItemIds, force },
+  });
+  if (error) return { error: error.message };
+  return { results: data?.results ?? [] };
 }
 
 async function requireMenuItemOwnership(supabase: Awaited<ReturnType<typeof createClient>>, vendorId: string, menuItemId: string) {
@@ -39,13 +55,66 @@ export async function upsertMenuItem(data: {
 }) {
   const { supabase, vendor } = await requireVendor();
 
-  const { error } = data.id
-    ? await supabase.from("menu_items").update({ ...data, vendor_id: vendor.id }).eq("id", data.id)
-    : await supabase.from("menu_items").insert({ ...data, vendor_id: vendor.id });
+  if (data.id) {
+    const { error } = await supabase
+      .from("menu_items")
+      .update({ ...data, vendor_id: vendor.id })
+      .eq("id", data.id);
+    if (error) return { error: error.message };
+    revalidatePath("/vendor/menu");
+    return { success: true };
+  }
 
-  if (error) return { error: error.message };
+  const { data: inserted, error } = await supabase
+    .from("menu_items")
+    .insert({ ...data, vendor_id: vendor.id })
+    .select("id")
+    .single();
+  if (error || !inserted) return { error: error?.message ?? "建立失敗" };
+
+  // Fire-and-forget AI tagging (runs after response is sent)
+  after(async () => {
+    await invokeAiTagGeneration(supabase, [inserted.id]).catch((e) =>
+      console.error("AI tag generation failed for", inserted.id, e),
+    );
+  });
+
   revalidatePath("/vendor/menu");
-  return { success: true };
+  return { success: true, id: inserted.id };
+}
+
+export async function regenerateAiMetadata(menuItemIds: string[]) {
+  const { supabase, vendor } = await requireVendor();
+  if (menuItemIds.length === 0) return { error: "請選擇至少一道餐點" };
+
+  // RLS check：只允許 invoke 自己擁有的 items
+  const { data: owned } = await supabase
+    .from("menu_items")
+    .select("id")
+    .eq("vendor_id", vendor.id)
+    .in("id", menuItemIds);
+  const ownedIds = (owned ?? []).map((r) => r.id);
+  if (ownedIds.length === 0) return { error: "權限不足" };
+
+  const result = await invokeAiTagGeneration(supabase, ownedIds, true);
+  revalidatePath("/vendor/menu");
+  return result;
+}
+
+export async function backfillMissingAiTags() {
+  const { supabase, vendor } = await requireVendor();
+  const { data: missing } = await supabase
+    .from("menu_items")
+    .select("id")
+    .eq("vendor_id", vendor.id)
+    .is("ai_generated_at", null)
+    .limit(100);
+  const ids = (missing ?? []).map((r) => r.id);
+  if (ids.length === 0) return { success: true, count: 0 };
+
+  const result = await invokeAiTagGeneration(supabase, ids);
+  revalidatePath("/vendor/menu");
+  return { ...result, count: ids.length };
 }
 
 export async function setDailySlot(menuItemId: string, date: string, maxQty: number) {

--- a/app/vendor/menu/ai-backfill-button.tsx
+++ b/app/vendor/menu/ai-backfill-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Sparkles } from "lucide-react";
+import { useTransition } from "react";
+import { backfillMissingAiTags } from "./actions";
+
+interface Props {
+  missingCount: number;
+}
+
+export function AiBackfillButton({ missingCount }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  if (missingCount === 0) return null;
+
+  function handleClick() {
+    startTransition(async () => {
+      const result = await backfillMissingAiTags();
+      if ("error" in result && result.error) {
+        alert(`AI 補完失敗：${result.error}`);
+        return;
+      }
+      const count = (result as { count?: number }).count ?? 0;
+      alert(`已為 ${count} 道餐點產生 AI 標籤`);
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={isPending}
+      className="flex items-center gap-1"
+    >
+      <Sparkles className="size-3.5" />
+      {isPending ? "產生中…" : `AI 補完 (${missingCount})`}
+    </Button>
+  );
+}

--- a/app/vendor/menu/page.tsx
+++ b/app/vendor/menu/page.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { AiBackfillButton } from "./ai-backfill-button";
 import { VendorMenuItemCard, type SlotStatus } from "./menu-item-card";
 import { SlotBanner } from "./slot-banner";
 import type { BulkSlotItem, SalesDataMap } from "./bulk-slot-dialog";
@@ -39,11 +40,12 @@ export default async function VendorMenuPage() {
   // Fetch all items with their slots (Supabase fetches all embedded rows)
   const { data: items } = await supabase
     .from("menu_items")
-    .select("id, name, description, price, is_available, default_max_qty, image_url, calories, protein, sodium, sugar, tags, daily_slots(id, date, max_qty, reserved_qty), item_option_groups(id, name, required, max_select, sort_order, item_options(id, name, price_delta, sort_order))")
+    .select("id, name, description, price, is_available, default_max_qty, image_url, calories, protein, sodium, sugar, tags, ai_tags, ai_description, ai_generated_at, daily_slots(id, date, max_qty, reserved_qty), item_option_groups(id, name, required, max_select, sort_order, item_options(id, name, price_delta, sort_order))")
     .eq("vendor_id", vendor.id)
     .order("name");
 
   const allItems = items ?? [];
+  const missingAiCount = allItems.filter((i) => !i.ai_generated_at).length;
 
   // Fetch 7-day sales data
   const sevenDaysAgoDate = new Date(now);
@@ -101,7 +103,10 @@ export default async function VendorMenuPage() {
     <div className="flex flex-col gap-4">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">{vendor.name} — 菜單管理</h1>
-        <Button size="sm">新增餐點</Button>
+        <div className="flex items-center gap-2">
+          <AiBackfillButton missingCount={missingAiCount} />
+          <Button size="sm">新增餐點</Button>
+        </div>
       </div>
 
       <SlotBanner

--- a/scripts/backfill-ai-tags.ts
+++ b/scripts/backfill-ai-tags.ts
@@ -1,0 +1,77 @@
+// Backfill AI tags + description + nutrition for every menu_item lacking them.
+//
+// Usage:
+//   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+//     bun run scripts/backfill-ai-tags.ts [--force]
+//
+// 對應 P2：直接跑 edge function `generate-menu-item-tags`，每批 50 筆。
+
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const FORCE = process.argv.includes("--force");
+const BATCH_SIZE = 50;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false },
+});
+
+async function main() {
+  const query = supabase.from("menu_items").select("id, name").order("name");
+  const { data: items, error } = FORCE
+    ? await query
+    : await query.is("ai_generated_at", null);
+
+  if (error) {
+    console.error("Failed to fetch items:", error.message);
+    process.exit(1);
+  }
+  if (!items || items.length === 0) {
+    console.log("Nothing to backfill.");
+    return;
+  }
+
+  console.log(`Backfilling ${items.length} items (force=${FORCE})…`);
+
+  let okCount = 0;
+  let errCount = 0;
+  let skipCount = 0;
+
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    const batch = items.slice(i, i + BATCH_SIZE);
+    console.log(`Batch ${i / BATCH_SIZE + 1}: ${batch.length} items…`);
+
+    const { data, error: invokeError } = await supabase.functions.invoke<{
+      results: Array<{ id: string; status: string; error?: string }>;
+    }>("generate-menu-item-tags", {
+      body: { menu_item_ids: batch.map((b) => b.id), force: FORCE },
+    });
+
+    if (invokeError) {
+      console.error("  invoke error:", invokeError.message);
+      errCount += batch.length;
+      continue;
+    }
+    for (const r of data?.results ?? []) {
+      if (r.status === "ok") okCount++;
+      else if (r.status === "skipped") skipCount++;
+      else {
+        errCount++;
+        console.error(`  ${r.id} error:`, r.error);
+      }
+    }
+  }
+
+  console.log(`Done. ok=${okCount} skipped=${skipCount} error=${errCount}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/functions/generate-menu-item-tags/deno.json
+++ b/supabase/functions/generate-menu-item-tags/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2",
+    "openai": "npm:openai@4"
+  }
+}

--- a/supabase/functions/generate-menu-item-tags/index.ts
+++ b/supabase/functions/generate-menu-item-tags/index.ts
@@ -1,0 +1,224 @@
+// generate-menu-item-tags
+//
+// Server Action / 後台 / backfill script invoke 進來，
+// 用 GPT-5.4-mini 對指定 menu_items 產 ai_tags + ai_description + 缺值的營養指標。
+//
+// Required Supabase secrets:
+//   OPENAI_API_KEY
+//   OPENAI_MODEL (optional, default "gpt-5.4-mini")
+//
+// 預設 SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY 由 Edge Runtime 注入。
+
+import { createClient } from "npm:@supabase/supabase-js@2";
+import OpenAI from "npm:openai@4";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")!;
+const OPENAI_MODEL = Deno.env.get("OPENAI_MODEL") ?? "gpt-5.4-mini";
+
+const SKIP_WITHIN_MS = 60_000;
+const MAX_ITEMS_PER_INVOKE = 100;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+interface RequestPayload {
+  menu_item_ids: string[];
+  force?: boolean;
+}
+
+interface VocabRow {
+  slug: string;
+  label: string;
+  axis: string;
+}
+
+interface MenuItemRow {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number;
+  calories: number | null;
+  protein: number | null;
+  sodium: number | null;
+  sugar: number | null;
+  tags: string[];
+  ai_generated_at: string | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: CORS_HEADERS });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ error: "missing auth" }, 401);
+
+  let payload: RequestPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  if (!Array.isArray(payload.menu_item_ids) || payload.menu_item_ids.length === 0) {
+    return json({ error: "menu_item_ids required" }, 400);
+  }
+  if (payload.menu_item_ids.length > MAX_ITEMS_PER_INVOKE) {
+    return json({ error: `max ${MAX_ITEMS_PER_INVOKE} items per invoke` }, 400);
+  }
+
+  const supabaseCaller = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: auth } },
+    auth: { persistSession: false },
+  });
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+
+  const { data: vocab, error: vocabError } = await supabaseAdmin
+    .from("tag_vocabulary")
+    .select("slug, label, axis")
+    .order("axis")
+    .order("sort_order");
+  if (vocabError || !vocab || vocab.length === 0) {
+    return json({ error: "vocab unavailable" }, 500);
+  }
+
+  const allSlugs = vocab.map((v: VocabRow) => v.slug);
+
+  // RLS check：caller 必須對這些 menu_items 有 SELECT 權限（=vendor owner 或 admin）
+  const { data: items, error: itemsError } = await supabaseCaller
+    .from("menu_items")
+    .select("id, name, description, price, calories, protein, sodium, sugar, tags, ai_generated_at")
+    .in("id", payload.menu_item_ids);
+  if (itemsError) return json({ error: itemsError.message }, 403);
+  if (!items || items.length === 0) return json({ error: "no accessible items" }, 403);
+
+  const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+  const systemPrompt = buildSystemPrompt(vocab as VocabRow[]);
+  const results: Array<{ id: string; status: "ok" | "skipped" | "error"; error?: string }> = [];
+
+  for (const raw of items as MenuItemRow[]) {
+    if (
+      !payload.force &&
+      raw.ai_generated_at &&
+      Date.now() - new Date(raw.ai_generated_at).getTime() < SKIP_WITHIN_MS
+    ) {
+      results.push({ id: raw.id, status: "skipped" });
+      continue;
+    }
+
+    try {
+      const completion = await openai.chat.completions.create({
+        model: OPENAI_MODEL,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: buildUserPrompt(raw) },
+        ],
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "menu_item_metadata",
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                tags: {
+                  type: "array",
+                  items: { type: "string", enum: allSlugs },
+                  minItems: 2,
+                  maxItems: 8,
+                },
+                description: { type: "string" },
+                calories: { type: ["integer", "null"] },
+                protein: { type: ["number", "null"] },
+                sodium: { type: ["number", "null"] },
+                sugar: { type: ["number", "null"] },
+              },
+              required: ["tags", "description", "calories", "protein", "sodium", "sugar"],
+            },
+            strict: true,
+          },
+        },
+      });
+
+      const content = completion.choices?.[0]?.message?.content;
+      if (!content) throw new Error("empty completion content");
+      const parsed = JSON.parse(content);
+
+      const uniqueTags = [...new Set<string>(parsed.tags ?? [])];
+      const update: Record<string, unknown> = {
+        ai_tags: uniqueTags,
+        ai_description: parsed.description,
+        ai_generated_at: new Date().toISOString(),
+      };
+      if (raw.calories == null && parsed.calories != null) update.calories = parsed.calories;
+      if (raw.protein == null && parsed.protein != null) update.protein = parsed.protein;
+      if (raw.sodium == null && parsed.sodium != null) update.sodium = parsed.sodium;
+      if (raw.sugar == null && parsed.sugar != null) update.sugar = parsed.sugar;
+
+      const { error: updateError } = await supabaseAdmin
+        .from("menu_items")
+        .update(update)
+        .eq("id", raw.id);
+      if (updateError) throw updateError;
+
+      results.push({ id: raw.id, status: "ok" });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      results.push({ id: raw.id, status: "error", error: message });
+    }
+  }
+
+  return json({ results }, 200);
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+function buildSystemPrompt(vocab: VocabRow[]): string {
+  const byAxis: Record<string, string[]> = {};
+  for (const v of vocab) {
+    (byAxis[v.axis] ??= []).push(`${v.slug}(${v.label})`);
+  }
+  const axes = Object.entries(byAxis)
+    .map(([axis, slugs]) => `- ${axis}: ${slugs.join(", ")}`)
+    .join("\n");
+
+  return `你是台灣校園訂餐平台的菜單分析助手。任務：給一道餐點，產出：
+1. tags：從以下 controlled vocabulary 選 2-8 個 slug，盡量跨多個 axis 涵蓋餐點特性，但每個 axis 至多 2 個。
+2. description：一句中文簡介（20-80 字），描述風味/口感/適合場合，不要重複菜名。
+3. calories / protein / sodium / sugar：若 existing_nutrition 對應欄位為 null 則估值（以同類餐點常見區間），不為 null 則一律回 null（系統不會覆蓋已填值）。
+
+Controlled vocabulary (slug-中文 label)：
+${axes}
+
+僅輸出 slug，不接受中文 label 也不接受 vocab 外的 tag。`;
+}
+
+function buildUserPrompt(item: MenuItemRow): string {
+  return JSON.stringify({
+    name: item.name,
+    vendor_description: item.description,
+    price: item.price,
+    vendor_tags: item.tags,
+    existing_nutrition: {
+      calories: item.calories,
+      protein: item.protein,
+      sodium: item.sodium,
+      sugar: item.sugar,
+    },
+  });
+}

--- a/supabase/migrations/20260526060740_ai_tag_vocabulary.sql
+++ b/supabase/migrations/20260526060740_ai_tag_vocabulary.sql
@@ -1,0 +1,127 @@
+-- ============================================================
+-- P2: AI tag vocabulary + menu_items AI metadata columns
+--
+-- 1. tag_vocabulary — controlled vocab (slug + 中文 label + axis)
+--    ~42 tags across 6 axes (taste / diet / cuisine / category /
+--    temperature / occasion). LLM 只能從此 pool 中選 tag。
+-- 2. menu_items.ai_tags / ai_description / ai_generated_at — AI
+--    生成的 metadata 欄位，與 vendor 自填的 tags 並存。
+-- 3. Trigger validate_ai_tags_in_vocab — DB 層強制 ai_tags 必須
+--    全在 tag_vocabulary，避免 vocab drift。
+-- ============================================================
+
+CREATE TABLE tag_vocabulary (
+  slug        text PRIMARY KEY,
+  label       text NOT NULL,
+  axis        text NOT NULL CHECK (axis IN ('taste','diet','cuisine','category','temperature','occasion')),
+  sort_order  int  NOT NULL DEFAULT 0,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE tag_vocabulary ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tag_vocabulary_read" ON tag_vocabulary FOR SELECT USING (true);
+
+-- 寫入只給 service_role + admin（admin 透過 has_role 檢查）
+CREATE POLICY "tag_vocabulary_admin_write" ON tag_vocabulary FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = (SELECT auth.uid()) AND 'admin' = ANY (profiles.role)
+    )
+  );
+
+-- ============================================================
+-- 初始 vocab seed — 42 tags
+-- ============================================================
+INSERT INTO tag_vocabulary (slug, label, axis, sort_order) VALUES
+  -- taste
+  ('refreshing',  '清爽',   'taste', 10),
+  ('rich',        '重口',   'taste', 20),
+  ('spicy',       '辣',     'taste', 30),
+  ('sweet',       '甜',     'taste', 40),
+  ('savoury',     '鹹香',   'taste', 50),
+  ('sour',        '酸',     'taste', 60),
+  -- diet
+  ('vegetarian',  '素食',   'diet', 10),
+  ('high-protein','高蛋白', 'diet', 20),
+  ('low-cal',     '低卡',   'diet', 30),
+  ('low-sodium',  '低鹽',   'diet', 40),
+  ('low-sugar',   '低糖',   'diet', 50),
+  ('healthy',     '健康',   'diet', 60),
+  -- cuisine
+  ('taiwanese',   '台式',   'cuisine', 10),
+  ('chinese',     '中式',   'cuisine', 20),
+  ('japanese',    '日式',   'cuisine', 30),
+  ('korean',      '韓式',   'cuisine', 40),
+  ('cantonese',   '港式',   'cuisine', 50),
+  ('thai',        '泰式',   'cuisine', 60),
+  ('indian',      '印度',   'cuisine', 70),
+  ('western',     '西式',   'cuisine', 80),
+  ('italian',     '義式',   'cuisine', 90),
+  ('american',    '美式',   'cuisine', 100),
+  ('mexican',     '墨西哥', 'cuisine', 110),
+  -- category
+  ('rice',        '飯',     'category', 10),
+  ('noodle',      '麵',     'category', 20),
+  ('soup',        '湯品',   'category', 30),
+  ('salad',       '沙拉',   'category', 40),
+  ('sandwich',    '三明治', 'category', 50),
+  ('drink',       '飲料',   'category', 60),
+  ('dessert',     '甜點',   'category', 70),
+  ('breakfast',   '早餐',   'category', 80),
+  ('bento',       '便當',   'category', 90),
+  ('hotpot',      '火鍋',   'category', 100),
+  ('bbq',         '燒烤',   'category', 110),
+  ('fried',       '炸物',   'category', 120),
+  -- temperature
+  ('hot',         '熱食',   'temperature', 10),
+  ('cold',        '冷食',   'temperature', 20),
+  ('frozen',      '冰品',   'temperature', 30),
+  -- occasion
+  ('addon',       '加購',   'occasion', 10),
+  ('filling',     '飽足',   'occasion', 20),
+  ('light',       '輕食',   'occasion', 30),
+  ('comfort',     '療癒',   'occasion', 40);
+
+-- ============================================================
+-- menu_items AI metadata 欄位
+-- ============================================================
+ALTER TABLE menu_items
+  ADD COLUMN ai_tags         text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN ai_description  text,
+  ADD COLUMN ai_generated_at timestamptz;
+
+CREATE INDEX menu_items_ai_tags_idx ON menu_items USING GIN (ai_tags);
+
+-- ============================================================
+-- validate_ai_tags — DB 強制 ai_tags ⊆ tag_vocabulary.slug
+-- ============================================================
+CREATE OR REPLACE FUNCTION validate_ai_tags() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  bad_tag text;
+BEGIN
+  IF NEW.ai_tags IS NULL OR NEW.ai_tags = '{}' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT t INTO bad_tag
+  FROM unnest(NEW.ai_tags) AS t
+  WHERE NOT EXISTS (SELECT 1 FROM tag_vocabulary WHERE slug = t)
+  LIMIT 1;
+
+  IF bad_tag IS NOT NULL THEN
+    RAISE EXCEPTION 'ai_tags contains slug % which is not in tag_vocabulary', bad_tag
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION validate_ai_tags() FROM anon, authenticated;
+
+CREATE TRIGGER menu_items_validate_ai_tags
+  BEFORE INSERT OR UPDATE OF ai_tags ON menu_items
+  FOR EACH ROW EXECUTE FUNCTION validate_ai_tags();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -7,6 +7,8 @@ export type Json =
   | Json[]
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "14.4"
   }
@@ -149,6 +151,9 @@ export type Database = {
       }
       menu_items: {
         Row: {
+          ai_description: string | null
+          ai_generated_at: string | null
+          ai_tags: string[]
           calories: number | null
           created_at: string
           default_max_qty: number
@@ -165,6 +170,9 @@ export type Database = {
           vendor_id: string
         }
         Insert: {
+          ai_description?: string | null
+          ai_generated_at?: string | null
+          ai_tags?: string[]
           calories?: number | null
           created_at?: string
           default_max_qty?: number
@@ -181,6 +189,9 @@ export type Database = {
           vendor_id: string
         }
         Update: {
+          ai_description?: string | null
+          ai_generated_at?: string | null
+          ai_tags?: string[]
           calories?: number | null
           created_at?: string
           default_max_qty?: number
@@ -372,6 +383,30 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      tag_vocabulary: {
+        Row: {
+          axis: string
+          created_at: string
+          label: string
+          slug: string
+          sort_order: number
+        }
+        Insert: {
+          axis: string
+          created_at?: string
+          label: string
+          slug: string
+          sort_order?: number
+        }
+        Update: {
+          axis?: string
+          created_at?: string
+          label?: string
+          slug?: string
+          sort_order?: number
+        }
+        Relationships: []
       }
       vendor_areas: {
         Row: {


### PR DESCRIPTION
## Summary
- **Schema**: `tag_vocabulary` (42-slug controlled vocab across 6 axes) + `menu_items.ai_tags / ai_description / ai_generated_at` 三欄 + GIN index + `validate_ai_tags` trigger (DB-level vocab enforcement，避免漂移)
- **Edge function** `generate-menu-item-tags`：GPT-5.4-mini structured outputs (enum-constrained to vocab)，**同時補缺值的營養指標**（只填 null，不覆蓋 vendor 已填值）。60s idempotency + max 100/invoke
- **Server actions**：`upsertMenuItem` 新增後用 Next 16 `after()` fire-and-forget invoke；`regenerateAiMetadata` + `backfillMissingAiTags` 給商家自助
- **UI**：`/vendor/menu` 加 `AI 補完 (N)` 按鈕，N 是該 vendor 還沒生 AI tag 的餐點數
- **Script** `scripts/backfill-ai-tags.ts`：用 service role 一次跑完全部 menu_items（初始 backfill）

## 為什麼這樣設計

業界共識（KAR / Pinterest / Instacart）：**絕不在 serving path 打 LLM**。本 PR 把 LLM call 全部放 offline（商家建菜時觸發 + 手動 batch），首頁將來只查 SQL/pgvector，p99 < 50ms 不打 OpenAI。

Controlled vocab（AgenticTagger paper）：開放給 LLM 自由生 tag 會 vocab drift（第一次「冰品」第二次「冷飲」第三次「消暑」），matching 完全爛。本 PR 用 OpenAI Structured Outputs `enum` 強制只能從 42 個 slug 中選，DB trigger 再校驗一遍。

## Setup（merge 後）
1. `supabase secrets set OPENAI_API_KEY=sk-...`
2. `supabase functions deploy generate-menu-item-tags`
3. 跑初始 backfill：
   ```bash
   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... bun run scripts/backfill-ai-tags.ts
   ```

## Test plan
- [x] Migration 已套到 production，`list_tables` 看得到 `tag_vocabulary`，`menu_items` 多三欄
- [x] Lint pass, 42 unit tests pass, `next build` 過（已排除 supabase/functions deno code）
- [ ] Edge function deploy 後在 `/vendor/menu` 點 `AI 補完`，看 menu items 是否拿到 ai_tags + ai_description
- [ ] 新建一道餐點 → 觀察 background invoke 是否成功（看 ai_generated_at 是否填）
- [ ] 驗證 vocab drift 防禦：直接 SQL `UPDATE menu_items SET ai_tags = '{nonexistent}' WHERE id = ...` 應被 trigger 阻擋

## Stack notes
- `tsconfig.json` 排除 `supabase/functions/`（Deno 環境 npm: imports 不該被 Next.js TS check）
- 用 `next/server` `after()`（Next.js 16 stable）做 fire-and-forget，避免阻塞 vendor 表單回應

是 4-phase recommendation overhaul 的 P2 of 4。P3（user preference tracking + ranking）+ P4（pgvector + 自然語言 search）接續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)