### PR TITLE
feat(rank): personalised home ranking via tag + nutrition preferences

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -8,7 +8,8 @@
 - Next.js 16 — App Router
 - Tailwind CSS 4
 - shadcn/ui (Radix UI primitives)
-- Supabase — Auth (Google OAuth + Email) + Postgres + RLS + Storage
+- Supabase — Auth (Google OAuth + Email) + Postgres + RLS + Storage + Edge Functions
+- OpenAI API (`gpt-5.4-mini`) — offline AI tag + description + nutrition fill for menu items
 
 ### Directory Structure
 ```
@@ -50,13 +51,28 @@ types/
 - `profiles` — User profiles (role: text[])
 - `vendors` — Vendor stores
 - `vendor_areas` — Vendor-area mapping (many-to-many)
-- `menu_items` — Menu items
+- `menu_items` — Menu items (incl. `ai_tags`, `ai_description`, `ai_generated_at` for LLM-derived metadata)
 - `item_option_groups` — Option groups per menu item
 - `item_options` — Individual options within a group
 - `daily_slots` — Daily quotas (core slot-limiting mechanism, has CHECK constraint)
 - `orders` — Orders
 - `order_items` — Order line items
 - `order_item_options` — Selected options per order item
+- `tag_vocabulary` — Controlled-vocab AI tags (42 slugs × 6 axes); `validate_ai_tags` trigger enforces `menu_items.ai_tags ⊆ tag_vocabulary.slug`
+- `user_tag_preferences` — Per-user tag affinity score, accumulated on order confirm
+- `user_nutrition_profile` — Per-user running average consumption (calories/protein/sodium/sugar)
+
+### DB Functions
+- `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally; returns ranked items with `match_score` (tag_match × 10 + nutrition_sim × 2 + ln(trend+1) × 5 + open_bonus) and explainable `top_tag_label`. Cold-start safe: anonymous / no-history users degrade gracefully to trending + open.
+- `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean.
+
+### Edge Functions
+- `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). 60s idempotency, max 100 items/invoke.
+
+### Recommendation pipeline (offline-only LLM)
+1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` (+ missing nutrition).
+2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile`.
+3. Home page calls `rank_menu_items_for_home` RPC → pure SQL ranking, no LLM in serving path.
 
 ### Roles
 - `user` — Employee

--- a/components/home-item-card.tsx
+++ b/components/home-item-card.tsx
@@ -26,8 +26,13 @@ export function HomeItemCard({ item }: Props) {
             className="object-cover"
           />
         )}
+        {item.top_tag_label && (
+          <span className="absolute top-2 left-2 text-caption font-semibold rounded-badge bg-brand text-white px-2 py-1">
+            因你喜歡 #{item.top_tag_label}
+          </span>
+        )}
         {!item.vendor_is_open && (
-          <span className="absolute top-2 left-2 text-caption font-semibold rounded-badge bg-card/90 px-2 py-1 text-muted-foreground">
+          <span className="absolute top-2 right-2 text-caption font-semibold rounded-badge bg-card/90 px-2 py-1 text-muted-foreground">
             暫停營業
           </span>
         )}
@@ -38,6 +43,9 @@ export function HomeItemCard({ item }: Props) {
           <p className="text-body-strong shrink-0">${item.price}</p>
         </div>
         <p className="text-meta text-muted-foreground truncate">{item.vendor_name}</p>
+        {item.ai_description && (
+          <p className="text-meta text-muted-foreground line-clamp-2">{item.ai_description}</p>
+        )}
         {(item.calories || item.protein) && (
           <div className="flex flex-wrap gap-x-2 text-caption text-muted-foreground">
             {item.calories && <span>{item.calories} kcal</span>}

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -19,54 +19,46 @@ export type HomeItem = {
   price: number;
   image_url: string | null;
   tags: string[];
+  ai_tags: string[];
+  ai_description: string | null;
   calories: number | null;
   protein: number | null;
   sodium: number | null;
   vendor_id: string;
   vendor_name: string;
   vendor_is_open: boolean;
+  match_score: number;
+  top_tag_label: string | null;
 };
 
 export async function getHomeItems(areaId?: string, limit = 60): Promise<HomeItem[]> {
   const supabase = await createClient();
 
-  const select = areaId
-    ? "id, name, description, price, image_url, tags, calories, protein, sodium, vendor_id, vendors!inner(id, name, is_active, is_open, vendor_areas!inner(area_id))"
-    : "id, name, description, price, image_url, tags, calories, protein, sodium, vendor_id, vendors!inner(id, name, is_active, is_open)";
+  const { data, error } = await supabase.rpc("rank_menu_items_for_home", {
+    p_area_id: areaId ?? undefined,
+    p_limit: limit,
+  });
 
-  let query = supabase
-    .from("menu_items")
-    .select(select)
-    .eq("is_available", true)
-    .eq("vendors.is_active", true);
+  if (error || !data) return [];
 
-  if (areaId) query = query.eq("vendors.vendor_areas.area_id", areaId);
-
-  const { data: items } = await query.limit(limit);
-  if (!items) return [];
-
-  return items
-    .map((item) => {
-      const vendor = item.vendors as { name: string; is_open: boolean } | null;
-      return {
-        id: item.id,
-        name: item.name,
-        description: item.description,
-        price: item.price,
-        image_url: item.image_url,
-        tags: item.tags ?? [],
-        calories: item.calories,
-        protein: item.protein,
-        sodium: item.sodium,
-        vendor_id: item.vendor_id,
-        vendor_name: vendor?.name ?? "",
-        vendor_is_open: vendor?.is_open ?? false,
-      };
-    })
-    .sort((a, b) => {
-      if (a.vendor_is_open !== b.vendor_is_open) return a.vendor_is_open ? -1 : 1;
-      return a.name.localeCompare(b.name, "zh-Hant");
-    });
+  return data.map((row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    price: row.price,
+    image_url: row.image_url,
+    tags: row.tags ?? [],
+    ai_tags: row.ai_tags ?? [],
+    ai_description: row.ai_description,
+    calories: row.calories,
+    protein: row.protein,
+    sodium: row.sodium,
+    vendor_id: row.vendor_id,
+    vendor_name: row.vendor_name,
+    vendor_is_open: row.vendor_is_open,
+    match_score: row.match_score,
+    top_tag_label: row.top_tag_label,
+  }));
 }
 
 export async function getTrendingItems(limit = 8, areaId?: string): Promise<RecommendedItem[]> {

--- a/supabase/migrations/20260526061413_user_preferences_ranking.sql
+++ b/supabase/migrations/20260526061413_user_preferences_ranking.sql
@@ -1,0 +1,258 @@
+-- ============================================================
+-- P3: User preference tracking + personalised ranking
+--
+-- 1. user_tag_preferences — per (user, tag) score 累積，每次 order
+--    confirmed 加一筆 +qty 分。
+-- 2. user_nutrition_profile — per user running avg of consumed
+--    calories/protein/sodium/sugar，用 incremental weighted mean。
+-- 3. Trigger update_user_preferences_on_confirm — orders.status
+--    'pending' → 'confirmed' 觸發累積，避免下單未確認就影響推薦。
+-- 4. SQL function rank_menu_items_for_home(p_area_id, p_limit) —
+--    SECURITY DEFINER，內部用 auth.uid() 取 caller 身份做 ranking。
+--    回傳 tag_match × nutrition_similarity × trend bonus 加權後的
+--    final score + explainable top_tag_label。
+-- ============================================================
+
+-- ============================================================
+-- user_tag_preferences
+-- ============================================================
+CREATE TABLE user_tag_preferences (
+  user_id       uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  tag_slug      text NOT NULL REFERENCES tag_vocabulary(slug) ON DELETE CASCADE,
+  score         numeric NOT NULL DEFAULT 0 CHECK (score >= 0),
+  last_event_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, tag_slug)
+);
+
+CREATE INDEX user_tag_preferences_user_score_idx
+  ON user_tag_preferences (user_id, score DESC);
+
+ALTER TABLE user_tag_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_tag_preferences_read_own" ON user_tag_preferences
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+-- ============================================================
+-- user_nutrition_profile — running avg
+-- ============================================================
+CREATE TABLE user_nutrition_profile (
+  user_id       uuid PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  avg_calories  numeric,
+  avg_protein   numeric,
+  avg_sodium    numeric,
+  avg_sugar     numeric,
+  sample_count  int NOT NULL DEFAULT 0,
+  last_event_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_nutrition_profile ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_nutrition_profile_read_own" ON user_nutrition_profile
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+-- ============================================================
+-- Trigger function: 確認訂單時累積 preferences
+-- ============================================================
+CREATE OR REPLACE FUNCTION update_user_preferences_on_confirm()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 只在 pending → confirmed 觸發
+  IF NEW.status IS DISTINCT FROM 'confirmed' OR OLD.status = 'confirmed' THEN
+    RETURN NEW;
+  END IF;
+
+  -- 累積 tag preferences (weight = qty)
+  INSERT INTO user_tag_preferences (user_id, tag_slug, score, last_event_at)
+  SELECT
+    NEW.user_id,
+    tag,
+    SUM(oi.qty)::numeric,
+    now()
+  FROM order_items oi
+  JOIN menu_items mi ON mi.id = oi.menu_item_id
+  CROSS JOIN LATERAL unnest(mi.ai_tags) AS t(tag)
+  WHERE oi.order_id = NEW.id
+  GROUP BY tag
+  ON CONFLICT (user_id, tag_slug) DO UPDATE
+    SET score = user_tag_preferences.score + EXCLUDED.score,
+        last_event_at = now();
+
+  -- 累積 nutrition profile (incremental weighted mean)
+  WITH order_avg AS (
+    SELECT
+      AVG(mi.calories::numeric) FILTER (WHERE mi.calories IS NOT NULL) AS calories,
+      AVG(mi.protein) FILTER (WHERE mi.protein IS NOT NULL) AS protein,
+      AVG(mi.sodium)  FILTER (WHERE mi.sodium IS NOT NULL)  AS sodium,
+      AVG(mi.sugar)   FILTER (WHERE mi.sugar IS NOT NULL)   AS sugar,
+      COUNT(*) AS n
+    FROM order_items oi
+    JOIN menu_items mi ON mi.id = oi.menu_item_id
+    WHERE oi.order_id = NEW.id
+  )
+  INSERT INTO user_nutrition_profile
+    (user_id, avg_calories, avg_protein, avg_sodium, avg_sugar, sample_count, last_event_at)
+  SELECT NEW.user_id, calories, protein, sodium, sugar, n, now()
+  FROM order_avg
+  WHERE n > 0
+  ON CONFLICT (user_id) DO UPDATE
+    SET
+      avg_calories = CASE
+        WHEN EXCLUDED.avg_calories IS NULL THEN user_nutrition_profile.avg_calories
+        WHEN user_nutrition_profile.avg_calories IS NULL THEN EXCLUDED.avg_calories
+        ELSE (user_nutrition_profile.avg_calories * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_calories * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      avg_protein = CASE
+        WHEN EXCLUDED.avg_protein IS NULL THEN user_nutrition_profile.avg_protein
+        WHEN user_nutrition_profile.avg_protein IS NULL THEN EXCLUDED.avg_protein
+        ELSE (user_nutrition_profile.avg_protein * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_protein * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      avg_sodium = CASE
+        WHEN EXCLUDED.avg_sodium IS NULL THEN user_nutrition_profile.avg_sodium
+        WHEN user_nutrition_profile.avg_sodium IS NULL THEN EXCLUDED.avg_sodium
+        ELSE (user_nutrition_profile.avg_sodium * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_sodium * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      avg_sugar = CASE
+        WHEN EXCLUDED.avg_sugar IS NULL THEN user_nutrition_profile.avg_sugar
+        WHEN user_nutrition_profile.avg_sugar IS NULL THEN EXCLUDED.avg_sugar
+        ELSE (user_nutrition_profile.avg_sugar * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_sugar * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      sample_count = user_nutrition_profile.sample_count + EXCLUDED.sample_count,
+      last_event_at = now();
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION update_user_preferences_on_confirm() FROM PUBLIC;
+
+CREATE TRIGGER update_preferences_on_order_confirm
+  AFTER UPDATE OF status ON orders
+  FOR EACH ROW
+  WHEN (NEW.status = 'confirmed' AND OLD.status IS DISTINCT FROM 'confirmed')
+  EXECUTE FUNCTION update_user_preferences_on_confirm();
+
+-- ============================================================
+-- rank_menu_items_for_home — ranking function
+-- ============================================================
+CREATE OR REPLACE FUNCTION rank_menu_items_for_home(
+  p_area_id uuid DEFAULT NULL,
+  p_limit   int  DEFAULT 60
+)
+RETURNS TABLE (
+  id              uuid,
+  name            text,
+  description     text,
+  price           numeric,
+  image_url       text,
+  ai_tags         text[],
+  ai_description  text,
+  tags            text[],
+  calories        int,
+  protein         numeric,
+  sodium          numeric,
+  vendor_id       uuid,
+  vendor_name     text,
+  vendor_is_open  boolean,
+  match_score     numeric,
+  top_tag_label   text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH caller AS (
+  SELECT (SELECT auth.uid()) AS user_id
+),
+user_tags AS (
+  SELECT tag_slug, score
+  FROM user_tag_preferences
+  WHERE user_id = (SELECT user_id FROM caller)
+),
+user_nutr AS (
+  SELECT avg_calories, avg_protein, avg_sodium, sample_count
+  FROM user_nutrition_profile
+  WHERE user_id = (SELECT user_id FROM caller)
+),
+trending AS (
+  SELECT oi.menu_item_id, SUM(oi.qty)::numeric AS recent_qty
+  FROM order_items oi
+  JOIN orders o ON o.id = oi.order_id
+  WHERE o.status IN ('confirmed', 'completed')
+    AND o.created_at > now() - interval '7 days'
+  GROUP BY oi.menu_item_id
+)
+SELECT
+  mi.id,
+  mi.name,
+  mi.description,
+  mi.price,
+  mi.image_url,
+  mi.ai_tags,
+  mi.ai_description,
+  mi.tags,
+  mi.calories,
+  mi.protein,
+  mi.sodium,
+  mi.vendor_id,
+  v.name AS vendor_name,
+  v.is_open AS vendor_is_open,
+  -- final score = tag_match * 10 + nutrition_sim * 2 + log(trend+1) * 5 + open_bonus
+  (
+    COALESCE((
+      SELECT SUM(ut.score)
+      FROM user_tags ut
+      WHERE ut.tag_slug = ANY (mi.ai_tags)
+    ), 0) * 10
+    +
+    CASE WHEN (SELECT sample_count FROM user_nutr) IS NOT NULL THEN
+      2.0 / (
+        1.0
+        + COALESCE(ABS(mi.calories - (SELECT avg_calories FROM user_nutr)) / 100.0, 0)
+        + COALESCE(ABS(mi.protein  - (SELECT avg_protein  FROM user_nutr)) / 10.0, 0)
+        + COALESCE(ABS(mi.sodium   - (SELECT avg_sodium   FROM user_nutr)) / 200.0, 0)
+      )
+    ELSE 0 END
+    +
+    LN(1 + COALESCE((SELECT recent_qty FROM trending t WHERE t.menu_item_id = mi.id), 0)) * 5
+    +
+    CASE WHEN v.is_open THEN 1 ELSE 0 END
+  )::numeric AS match_score,
+  -- top tag (explainable badge)
+  (
+    SELECT tv.label
+    FROM user_tags ut
+    JOIN tag_vocabulary tv ON tv.slug = ut.tag_slug
+    WHERE ut.tag_slug = ANY (mi.ai_tags)
+    ORDER BY ut.score DESC
+    LIMIT 1
+  ) AS top_tag_label
+FROM menu_items mi
+JOIN vendors v ON v.id = mi.vendor_id
+WHERE mi.is_available = true
+  AND v.is_active = true
+  AND (
+    p_area_id IS NULL
+    OR EXISTS (
+      SELECT 1 FROM vendor_areas va
+      WHERE va.vendor_id = v.id AND va.area_id = p_area_id
+    )
+  )
+ORDER BY match_score DESC NULLS LAST, mi.name ASC
+LIMIT p_limit;
+$$;
+
+-- 只給 authenticated + anon 呼叫，function 內部自己用 auth.uid() 鎖身份
+GRANT EXECUTE ON FUNCTION rank_menu_items_for_home(uuid, int) TO anon, authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -408,6 +408,80 @@ export type Database = {
         }
         Relationships: []
       }
+      user_nutrition_profile: {
+        Row: {
+          avg_calories: number | null
+          avg_protein: number | null
+          avg_sodium: number | null
+          avg_sugar: number | null
+          last_event_at: string
+          sample_count: number
+          user_id: string
+        }
+        Insert: {
+          avg_calories?: number | null
+          avg_protein?: number | null
+          avg_sodium?: number | null
+          avg_sugar?: number | null
+          last_event_at?: string
+          sample_count?: number
+          user_id: string
+        }
+        Update: {
+          avg_calories?: number | null
+          avg_protein?: number | null
+          avg_sodium?: number | null
+          avg_sugar?: number | null
+          last_event_at?: string
+          sample_count?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_nutrition_profile_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_tag_preferences: {
+        Row: {
+          last_event_at: string
+          score: number
+          tag_slug: string
+          user_id: string
+        }
+        Insert: {
+          last_event_at?: string
+          score?: number
+          tag_slug: string
+          user_id: string
+        }
+        Update: {
+          last_event_at?: string
+          score?: number
+          tag_slug?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_tag_preferences_tag_slug_fkey"
+            columns: ["tag_slug"]
+            isOneToOne: false
+            referencedRelation: "tag_vocabulary"
+            referencedColumns: ["slug"]
+          },
+          {
+            foreignKeyName: "user_tag_preferences_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       vendor_areas: {
         Row: {
           area_id: string
@@ -501,6 +575,27 @@ export type Database = {
     Functions: {
       is_admin: { Args: never; Returns: boolean }
       is_vendor_order: { Args: { order_id: string }; Returns: boolean }
+      rank_menu_items_for_home: {
+        Args: { p_area_id?: string; p_limit?: number }
+        Returns: {
+          ai_description: string
+          ai_tags: string[]
+          calories: number
+          description: string
+          id: string
+          image_url: string
+          match_score: number
+          name: string
+          price: number
+          protein: number
+          sodium: number
+          tags: string[]
+          top_tag_label: string
+          vendor_id: string
+          vendor_is_open: boolean
+          vendor_name: string
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
- **Schema**：`user_tag_preferences` + `user_nutrition_profile` + `update_user_preferences_on_confirm` trigger（orders pending→confirmed 觸發）+ `rank_menu_items_for_home` RPC（SECURITY DEFINER，內部用 `auth.uid()` 鎖身份）
- **Ranking formula**：`tag_match × 10 + nutrition_sim × 2 + ln(7d_sales+1) × 5 + open_bonus`，cold-start 用戶降級為 trending + open（不掛）
- **UI**：HomeItemCard 加 brand-color badge「因你喜歡 #港式」（top_tag_label）；ai_description 顯示為兩行 subtitle
- **架構文件**：`.claude/rules/architecture.md` 同步更新（新表 + functions + edge function + offline-only LLM pipeline 說明）

## 為什麼這樣設計

1. **Ranking 走 pure SQL，serving 不打 LLM** — 跟 P2 同精神，全部 LLM call 都在 offline（trigger 上）。首頁 RPC p99 應 < 100ms（85 items × 1 GIN index lookup × 1 trending CTE）
2. **SECURITY DEFINER + `auth.uid()` internal** — 比「傳 p_user_id 進來再 check」安全。即使 client 偽造 user_id，function 只認 JWT
3. **Incremental running mean** — 每次 confirmed 不需要重掃 user 歷史，trigger 用 CASE WHEN 處理 NULL 合併。30-day decay 後續再加（user_tag_preferences.last_event_at 已有 ready）
4. **Top_tag_label 可解釋性** — 業界 Spotify narrative 推薦顯示「為什麼」CTR +4×（[Spotify Research 2024](https://research.atspotify.com/2024/12/contextualized-recommendations-through-personalized-narratives-using-llms)）。本實作 zero-cost 版

## Setup（merge 後）
無新 secret，無需 deploy edge function。Migration 已套 prod，trigger 對未來訂單生效；要回填現有 154 筆 orders 的 preferences 可選跑：
```sql
UPDATE orders SET status = status WHERE status = 'confirmed';
-- 觸發 trigger 重新累積，OK 因為 ON CONFLICT DO UPDATE 是 incremental
```
注意：這會 double-count 已 confirmed 訂單；要乾淨 backfill 得清空 user_tag_preferences 後跑一次性 SQL（看是否需要再決定）

## Test plan
- [x] Migration 已套，`rank_menu_items_for_home(NULL, 5)` 在 SQL editor 跑得通，cold-start case 全 items match_score = 1.0（vendor open bonus 唯一訊號）
- [x] Lint pass, 42 unit tests pass, `next build` 過
- [ ] Edge function deploy + backfill AI tags 後，重新跑 RPC 應看到 trending bonus 拉動排序
- [ ] 真的下一筆訂單 → confirmed → 看 user_tag_preferences 表是否累積對應 tag
- [ ] 首頁 logged-in 應看到「因你喜歡 #xxx」brand badge（前提：該 user 有至少一筆 confirmed 訂單）

## Stack notes
- P2 ↔ P3 解耦：即使 ai_tags 為空也不會 crash，rank function 對 empty array 安全（`tag_match = 0`）
- 不寫 30-day decay，避免 trigger 邏輯爆炸；保留 last_event_at 讓未來加 decay 時 read-side 處理即可

是 4-phase recommendation overhaul 的 P3 of 4。P4（pgvector embeddings + 自然語言 search）接續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)