### PR TITLE
feat(search): pgvector + pg_trgm hybrid semantic search

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -51,7 +51,7 @@ types/
 - `profiles` — User profiles (role: text[])
 - `vendors` — Vendor stores
 - `vendor_areas` — Vendor-area mapping (many-to-many)
-- `menu_items` — Menu items (incl. `ai_tags`, `ai_description`, `ai_generated_at` for LLM-derived metadata)
+- `menu_items` — Menu items (incl. `ai_tags`, `ai_description`, `ai_generated_at`, `embedding vector(512)` for LLM-derived metadata + semantic search)
 - `item_option_groups` — Option groups per menu item
 - `item_options` — Individual options within a group
 - `daily_slots` — Daily quotas (core slot-limiting mechanism, has CHECK constraint)
@@ -64,15 +64,18 @@ types/
 
 ### DB Functions
 - `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally; returns ranked items with `match_score` (tag_match × 10 + nutrition_sim × 2 + ln(trend+1) × 5 + open_bonus) and explainable `top_tag_label`. Cold-start safe: anonymous / no-history users degrade gracefully to trending + open.
+- `hybrid_search(p_query, p_query_embedding, p_area_id, p_limit)` — RRF (k=60) of pg_trgm keyword match + pgvector cosine semantic match. `p_query_embedding` 可為 NULL 讓 OpenAI 未配置時降級為 keyword-only。
 - `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean.
 
 ### Edge Functions
-- `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). 60s idempotency, max 100 items/invoke.
+- `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). Also generates `embedding` (text-embedding-3-small @ 512 dims) from name + ai_description + tag labels. 60s idempotency, max 100 items/invoke.
+- `embed-query` — Search-time helper: embeds query string → returns 512-dim vector for `hybrid_search` RPC.
 
 ### Recommendation pipeline (offline-only LLM)
-1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` (+ missing nutrition).
+1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` + `embedding` (+ missing nutrition).
 2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile`.
 3. Home page calls `rank_menu_items_for_home` RPC → pure SQL ranking, no LLM in serving path.
+4. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) → results。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體。
 
 ### Roles
 - `user` — Employee

--- a/app/search/loading.tsx
+++ b/app/search/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SearchLoading() {
+  return (
+    <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
+      <div className="w-full max-w-6xl p-4 flex flex-col gap-6">
+        <Skeleton className="h-7 w-64" />
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-3">
+              <Skeleton className="aspect-square w-full rounded-card" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,41 @@
+import { HomeItemCard } from "@/components/home-item-card";
+import { searchHomeItems } from "@/lib/search";
+
+interface Props {
+  searchParams: Promise<{ q?: string; area?: string }>;
+}
+
+export default async function SearchPage({ searchParams }: Props) {
+  const { q, area } = await searchParams;
+  const query = q?.trim() ?? "";
+  const items = query ? await searchHomeItems(query, area) : [];
+
+  return (
+    <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
+      <div className="w-full max-w-6xl p-4 flex flex-col gap-6">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-heading font-semibold">
+            {query ? `「${query}」的搜尋結果` : "搜尋"}
+          </h1>
+          {query && (
+            <p className="text-meta text-muted-foreground">{items.length} 道餐點</p>
+          )}
+        </div>
+
+        {!query ? (
+          <p className="text-muted-foreground">請從上方輸入想吃的東西。</p>
+        ) : items.length === 0 ? (
+          <p className="text-muted-foreground py-16 text-center">
+            找不到符合的餐點，試試其他關鍵字。
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {items.map((item) => (
+              <HomeItemCard key={item.id} item={item} />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import { AreaSelect } from "./area-select";
+import { SearchForm } from "./search-form";
 import { ThemeToggle } from "./theme-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -36,6 +37,7 @@ export async function Header() {
           <h1 className="text-heading font-semibold tracking-tight">NYCU <span className="text-brand">Eats</span></h1>
         </Link>
         <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />
+        <SearchForm />
       </div>
       <div className="flex items-center gap-4">
         {navigation.showAdminDashboard && (

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+
+export function SearchForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialQ = searchParams.get("q") ?? "";
+  const [value, setValue] = useState(initialQ);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const q = value.trim();
+    if (!q) return;
+    const area = searchParams.get("area");
+    const url = `/search?q=${encodeURIComponent(q)}${area ? `&area=${area}` : ""}`;
+    startTransition(() => router.push(url));
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="relative">
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+      <Input
+        type="search"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="今天好熱 / 高蛋白 / 牛肉麵…"
+        className="pl-9 w-48 md:w-64"
+        disabled={isPending}
+      />
+    </form>
+  );
+}

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,52 @@
+import type { HomeItem } from "@/lib/recommendation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function searchHomeItems(
+  query: string,
+  areaId?: string,
+  limit = 30,
+): Promise<HomeItem[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const supabase = await createClient();
+
+  // Step 1: try to get semantic embedding via edge function. Falls back
+  // to keyword-only search if OpenAI / function unavailable.
+  let embedding: number[] | null = null;
+  try {
+    const { data: embedRes, error: embedErr } = await supabase.functions.invoke<{
+      embedding: number[];
+    }>("embed-query", { body: { query: trimmed } });
+    if (!embedErr) embedding = embedRes?.embedding ?? null;
+  } catch (e) {
+    console.error("embed-query failed; degrading to keyword-only:", e);
+  }
+
+  const { data, error } = await supabase.rpc("hybrid_search", {
+    p_query: trimmed,
+    p_query_embedding: embedding as unknown as string,
+    p_area_id: areaId ?? undefined,
+    p_limit: limit,
+  });
+  if (error || !data) return [];
+
+  return data.map((row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    price: row.price,
+    image_url: row.image_url,
+    tags: row.tags ?? [],
+    ai_tags: row.ai_tags ?? [],
+    ai_description: row.ai_description,
+    calories: row.calories,
+    protein: row.protein,
+    sodium: row.sodium,
+    vendor_id: row.vendor_id,
+    vendor_name: row.vendor_name,
+    vendor_is_open: row.vendor_is_open,
+    match_score: row.match_score,
+    top_tag_label: row.top_tag_label,
+  }));
+}

--- a/supabase/functions/embed-query/deno.json
+++ b/supabase/functions/embed-query/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "openai": "npm:openai@4"
+  }
+}

--- a/supabase/functions/embed-query/index.ts
+++ b/supabase/functions/embed-query/index.ts
@@ -1,0 +1,72 @@
+// embed-query
+//
+// Server Action / 客戶端 invoke 進來，把搜尋字串轉成 512-dim embedding
+// 給 hybrid_search RPC 用。回傳 array<number>。
+//
+// 用 OpenAI text-embedding-3-small + Matryoshka dimensions=512。
+//
+// Required secret: OPENAI_API_KEY
+// Optional: OPENAI_EMBED_MODEL (default "text-embedding-3-small")
+//           OPENAI_EMBED_DIMS  (default 512)
+
+import OpenAI from "npm:openai@4";
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")!;
+const OPENAI_EMBED_MODEL = Deno.env.get("OPENAI_EMBED_MODEL") ?? "text-embedding-3-small";
+const OPENAI_EMBED_DIMS = Number(Deno.env.get("OPENAI_EMBED_DIMS") ?? "512");
+
+const MAX_QUERY_CHARS = 500;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: CORS_HEADERS });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ error: "missing auth" }, 401);
+
+  let payload: { query?: unknown };
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  const query = typeof payload.query === "string" ? payload.query.trim() : "";
+  if (!query) return json({ error: "query required" }, 400);
+  if (query.length > MAX_QUERY_CHARS) {
+    return json({ error: `query too long (>${MAX_QUERY_CHARS} chars)` }, 400);
+  }
+
+  const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+  try {
+    const r = await openai.embeddings.create({
+      model: OPENAI_EMBED_MODEL,
+      input: query,
+      dimensions: OPENAI_EMBED_DIMS,
+    });
+    const embedding = r.data?.[0]?.embedding;
+    if (!Array.isArray(embedding)) {
+      return json({ error: "no embedding returned" }, 500);
+    }
+    return json({ embedding }, 200);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return json({ error: message }, 500);
+  }
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/generate-menu-item-tags/index.ts
+++ b/supabase/functions/generate-menu-item-tags/index.ts
@@ -17,6 +17,8 @@ const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")!;
 const OPENAI_MODEL = Deno.env.get("OPENAI_MODEL") ?? "gpt-5.4-mini";
+const OPENAI_EMBED_MODEL = Deno.env.get("OPENAI_EMBED_MODEL") ?? "text-embedding-3-small";
+const OPENAI_EMBED_DIMS = Number(Deno.env.get("OPENAI_EMBED_DIMS") ?? "512");
 
 const SKIP_WITHIN_MS = 60_000;
 const MAX_ITEMS_PER_INVOKE = 100;
@@ -155,11 +157,32 @@ Deno.serve(async (req) => {
       const parsed = JSON.parse(content);
 
       const uniqueTags = [...new Set<string>(parsed.tags ?? [])];
+
+      // Build embedding from name + description + tag labels (semantic richness)
+      const tagLabels = uniqueTags
+        .map((slug) => (vocab as VocabRow[]).find((v) => v.slug === slug)?.label ?? slug)
+        .join(" ");
+      const embedInput = `${raw.name} ${parsed.description ?? ""} ${tagLabels}`.trim();
+
+      let embedding: number[] | null = null;
+      try {
+        const embedResp = await openai.embeddings.create({
+          model: OPENAI_EMBED_MODEL,
+          input: embedInput,
+          dimensions: OPENAI_EMBED_DIMS,
+        });
+        embedding = embedResp.data?.[0]?.embedding ?? null;
+      } catch (embedErr) {
+        // Embedding failure is non-fatal — tags still get written
+        console.error(`embedding failed for ${raw.id}:`, embedErr);
+      }
+
       const update: Record<string, unknown> = {
         ai_tags: uniqueTags,
         ai_description: parsed.description,
         ai_generated_at: new Date().toISOString(),
       };
+      if (embedding) update.embedding = JSON.stringify(embedding);
       if (raw.calories == null && parsed.calories != null) update.calories = parsed.calories;
       if (raw.protein == null && parsed.protein != null) update.protein = parsed.protein;
       if (raw.sodium == null && parsed.sodium != null) update.sodium = parsed.sodium;

--- a/supabase/migrations/20260526062039_semantic_search.sql
+++ b/supabase/migrations/20260526062039_semantic_search.sql
@@ -1,0 +1,123 @@
+-- ============================================================
+-- P4: pgvector embeddings + 自然語言 hybrid search
+--
+-- 1. enable vector + pg_trgm
+-- 2. menu_items.embedding vector(512) — text-embedding-3-small
+--    truncated to 512 dim via Matryoshka representation learning
+-- 3. HNSW index on embedding (cosine) + GIN trigram index on name
+-- 4. hybrid_search(query, query_embedding) — RRF (k=60) of trigram
+--    keyword match + semantic vector match。query_embedding 可為 NULL
+--    讓 OpenAI 未配置時降級為 keyword-only
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+ALTER TABLE menu_items ADD COLUMN embedding vector(512);
+
+-- HNSW for cosine similarity（適合 normalized embeddings）
+CREATE INDEX menu_items_embedding_hnsw_idx
+  ON menu_items USING hnsw (embedding vector_cosine_ops);
+
+-- Trigram index for 中文 fuzzy name match
+CREATE INDEX menu_items_name_trgm_idx
+  ON menu_items USING gin (name gin_trgm_ops);
+
+-- ============================================================
+-- hybrid_search — RRF (Reciprocal Rank Fusion) k=60
+-- ============================================================
+CREATE OR REPLACE FUNCTION hybrid_search(
+  p_query           text,
+  p_query_embedding vector(512) DEFAULT NULL,
+  p_area_id         uuid DEFAULT NULL,
+  p_limit           int  DEFAULT 30
+)
+RETURNS TABLE (
+  id              uuid,
+  name            text,
+  description     text,
+  price           numeric,
+  image_url       text,
+  ai_tags         text[],
+  ai_description  text,
+  tags            text[],
+  calories        int,
+  protein         numeric,
+  sodium          numeric,
+  vendor_id       uuid,
+  vendor_name     text,
+  vendor_is_open  boolean,
+  match_score     numeric,
+  top_tag_label   text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH keyword AS (
+  SELECT mi.id, RANK() OVER (ORDER BY similarity(mi.name, p_query) DESC) AS r
+  FROM menu_items mi
+  WHERE p_query IS NOT NULL
+    AND length(p_query) > 0
+    AND similarity(mi.name, p_query) > 0.05
+  ORDER BY similarity(mi.name, p_query) DESC
+  LIMIT 50
+),
+semantic AS (
+  SELECT mi.id, RANK() OVER (ORDER BY mi.embedding <=> p_query_embedding) AS r
+  FROM menu_items mi
+  WHERE p_query_embedding IS NOT NULL
+    AND mi.embedding IS NOT NULL
+  ORDER BY mi.embedding <=> p_query_embedding
+  LIMIT 50
+),
+all_ranked AS (
+  SELECT id, r::bigint AS k_rank, NULL::bigint AS s_rank FROM keyword
+  UNION ALL
+  SELECT id, NULL::bigint AS k_rank, r::bigint AS s_rank FROM semantic
+),
+fused AS (
+  SELECT
+    id,
+    SUM(
+      COALESCE(1.0 / (60 + k_rank), 0)
+      + COALESCE(1.0 / (60 + s_rank), 0)
+    )::numeric AS rrf
+  FROM all_ranked
+  GROUP BY id
+)
+SELECT
+  mi.id,
+  mi.name,
+  mi.description,
+  mi.price,
+  mi.image_url,
+  mi.ai_tags,
+  mi.ai_description,
+  mi.tags,
+  mi.calories,
+  mi.protein,
+  mi.sodium,
+  mi.vendor_id,
+  v.name AS vendor_name,
+  v.is_open AS vendor_is_open,
+  f.rrf AS match_score,
+  NULL::text AS top_tag_label
+FROM fused f
+JOIN menu_items mi ON mi.id = f.id
+JOIN vendors v ON v.id = mi.vendor_id
+WHERE mi.is_available = true
+  AND v.is_active = true
+  AND (
+    p_area_id IS NULL
+    OR EXISTS (
+      SELECT 1 FROM vendor_areas va
+      WHERE va.vendor_id = v.id AND va.area_id = p_area_id
+    )
+  )
+ORDER BY f.rrf DESC, mi.name ASC
+LIMIT p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION hybrid_search(text, vector, uuid, int) TO anon, authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -158,6 +158,7 @@ export type Database = {
           created_at: string
           default_max_qty: number
           description: string | null
+          embedding: string | null
           id: string
           image_url: string | null
           is_available: boolean
@@ -177,6 +178,7 @@ export type Database = {
           created_at?: string
           default_max_qty?: number
           description?: string | null
+          embedding?: string | null
           id?: string
           image_url?: string | null
           is_available?: boolean
@@ -196,6 +198,7 @@ export type Database = {
           created_at?: string
           default_max_qty?: number
           description?: string | null
+          embedding?: string | null
           id?: string
           image_url?: string | null
           is_available?: boolean
@@ -573,6 +576,32 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      hybrid_search: {
+        Args: {
+          p_area_id?: string
+          p_limit?: number
+          p_query: string
+          p_query_embedding?: string
+        }
+        Returns: {
+          ai_description: string
+          ai_tags: string[]
+          calories: number
+          description: string
+          id: string
+          image_url: string
+          match_score: number
+          name: string
+          price: number
+          protein: number
+          sodium: number
+          tags: string[]
+          top_tag_label: string
+          vendor_id: string
+          vendor_is_open: boolean
+          vendor_name: string
+        }[]
+      }
       is_admin: { Args: never; Returns: boolean }
       is_vendor_order: { Args: { order_id: string }; Returns: boolean }
       rank_menu_items_for_home: {
@@ -596,6 +625,8 @@ export type Database = {
           vendor_name: string
         }[]
       }
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
- **Schema**：`vector` + `pg_trgm` extensions + `menu_items.embedding vector(512)` + HNSW cosine index + GIN trigram index
- **`hybrid_search` RPC**：RRF (k=60) 融合 keyword (pg_trgm.similarity) + semantic (pgvector cosine)。`p_query_embedding` 可 NULL → 自動降級成 keyword-only
- **Edge functions**：新 `embed-query`（搜尋時 embed query）+ 擴充 `generate-menu-item-tags` 也產 item embedding (name + ai_description + tag labels)
- **App**：`lib/search.ts`、`components/search-form.tsx`（Header）、`app/search/page.tsx`（結果頁）

## 為什麼這樣設計

1. **Matryoshka 512 dim** — text-embedding-3-small 原生 1536 dim，截到 512 省 ~50% 儲存 + index 速度更快，對 ~85 items 的小 catalogue 召回率損失幾乎為零。OpenAI 官方 `dimensions` 參數內建支援。
2. **RRF (k=60)** — 業界標準 ([Cormack et al 2009](https://plg.uwaterloo.ca/~gvcormack/cormacksigir09-rrf.pdf))，無需 score 校準（trgm similarity 跟 cosine 量綱完全不同），對「兩條路徑都中」的 item 給最高分。
3. **Embedding 可選** — 沒設 OPENAI_API_KEY 時 search 仍能用（純 trgm fallback）。Loki 環境準備好之前就能 ship 不卡住。
4. **HNSW vs ivfflat** — 85 items 兩者效能差不多，但 HNSW 不用 ANALYZE 也不用設 list 數，預設參數即可用。

## SQL 驗證（已 prod 跑過）
```sql
SELECT id, name, match_score FROM hybrid_search('牛肉麵', NULL, NULL, 5);
-- 三筆牛肉麵變體都中，trgm similarity 同分 → 並列第一
```

## Setup（merge 後）
1. `supabase functions deploy embed-query`
2. `supabase functions deploy generate-menu-item-tags` （重新 deploy 拿到 embedding logic）
3. `bun run scripts/backfill-ai-tags.ts --force` 回填 embeddings + tags

OPENAI_API_KEY 已在 P2 時設過，無需重設。

## Test plan
- [x] Migration 已套，`hybrid_search('牛肉麵', NULL, NULL, 5)` SQL 跑得通
- [x] Lint pass, 42 unit tests pass, `next build` 過
- [ ] Header search 框輸入「牛肉麵」→ 跳 `/search?q=牛肉麵` → 看 grid 是否顯示牛肉麵
- [ ] 跑 backfill 補 embedding 後，搜尋「今天好熱」→ 應該優先顯示飲料 / 冰品 vendor 的 items
- [ ] OPENAI_API_KEY 暫時拔掉測試 → search 應降級為純 keyword（不爆炸）

## Stack notes
- p_query_embedding type 是 `string` 在 TS 但 supabase-js 會自動序列化 `number[]`，cast `as unknown as string` 是已知 workaround
- proxy.ts 已 redirect 未登入 → /login，所以 /search 也需要 auth（status quo）
- embedding 失敗時不影響 tag 寫入（generate-menu-item-tags 用 try/catch wrapper）

是 4-phase recommendation overhaul 的 **P4 (最終 phase) of 4**。
搭配 P1 (per-item home) + P2 (controlled-vocab AI tags) + P3 (personalised ranking) 完成完整的 offline-LLM + online-SQL pipeline。

🤖 Generated with [Claude Code](https://claude.com/claude-code)