### PR TITLE
chore: smaller default backfill batch + ignore supabase/.temp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 /playwright/.cache/
 /e2e/.auth/
 .playwright-mcp/
+
+# Supabase CLI scratch
+/supabase/.temp/

--- a/scripts/backfill-ai-tags.ts
+++ b/scripts/backfill-ai-tags.ts
@@ -11,7 +11,7 @@ import { createClient } from "@supabase/supabase-js";
 const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const FORCE = process.argv.includes("--force");
-const BATCH_SIZE = 50;
+const BATCH_SIZE = Number(process.env.BATCH_SIZE ?? "10");
 
 if (!SUPABASE_URL || !SERVICE_KEY) {
   console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");


### PR DESCRIPTION
## Summary
Two follow-ups discovered while running the actual P2/P4 backfill against production:

- `scripts/backfill-ai-tags.ts`: default BATCH_SIZE 50 → 10, env-overridable. 50 items × ~3-5s (chat + embed + DB write) overshoots the managed-tier 60s Edge Function wall-clock; 10 keeps each invocation well under budget. **Tested: 85 items in 9 batches, 0 errors.**
- `.gitignore`: add `/supabase/.temp/` (CLI scratch dir from `supabase secrets`/`functions deploy`).

## Test plan
- [x] `bun run scripts/backfill-ai-tags.ts` 跑完 85 items 全 ok
- [x] `BATCH_SIZE=N` env override 有效

🤖 Generated with [Claude Code](https://claude.com/claude-code)