### PR TITLE
style(layout): drop max-w-6xl page cap, go full-width

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -18,7 +18,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <nav className="flex gap-2">
           <Link href="/admin">
             <Button variant="outline" size="sm">營運總覽</Button>

--- a/app/cart/loading.tsx
+++ b/app/cart/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function CartLoading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <Skeleton className="h-8 w-36" />
         {Array.from({ length: 2 }).map((_, i) => (
           <div key={i} className="flex flex-col gap-2">

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -34,7 +34,7 @@ export default async function CartPage() {
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <h1 className="text-2xl font-bold">我的預約單</h1>
 
         {dates.length === 0 && (

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function HomeLoading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4">
+      <div className="w-full p-4">
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           {Array.from({ length: 8 }).map((_, i) => (
             <div key={i} className="flex flex-col gap-3">

--- a/app/menu/[id]/loading.tsx
+++ b/app/menu/[id]/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function MenuLoading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-2">
+      <div className="w-full p-4 flex flex-col gap-2">
         {/* 橫幅 */}
         <Skeleton className="w-full rounded-lg" style={{ aspectRatio: "16/5" }} />
         {/* 標題 */}

--- a/app/menu/[id]/page.tsx
+++ b/app/menu/[id]/page.tsx
@@ -40,7 +40,7 @@ export default async function MenuPage({ params }: Props) {
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-2">
+      <div className="w-full p-4 flex flex-col gap-2">
         <AspectRatio className="bg-muted rounded-lg overflow-hidden" ratio={16 / 5}>
           {vendor.image_url && (
             <Image src={vendor.image_url} alt={vendor.name} fill sizes="(max-width: 1152px) 100vw, 1152px" className="object-cover" priority />

--- a/app/orders/[id]/loading.tsx
+++ b/app/orders/[id]/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function Loading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-4 w-32" />
         <Skeleton className="h-4 w-24" />

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -68,7 +68,7 @@ export default async function OrderDetailPage({
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h1 className="text-2xl font-bold">訂單 #{shortId}</h1>
           <p className="text-sm text-muted-foreground">

--- a/app/orders/loading.tsx
+++ b/app/orders/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function OrdersLoading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <Skeleton className="h-8 w-32" />
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} className="h-28 w-full rounded-lg" />

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -6,7 +6,7 @@ export default async function OrdersPage() {
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <h1 className="text-2xl font-bold">我的訂單</h1>
         <OrderList initial={orders} initialHasMore={hasMore} />
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ export default async function HomePage({ searchParams }: Props) {
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="w-full max-w-6xl p-4 flex flex-col gap-8">
+      <div className="w-full p-4 flex flex-col gap-8">
         {hasCarousels && (
           <div className="flex flex-col gap-6">
             {trending.length > 0 && (

--- a/app/search/loading.tsx
+++ b/app/search/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function SearchLoading() {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="w-full max-w-6xl p-4 flex flex-col gap-6">
+      <div className="w-full p-4 flex flex-col gap-6">
         <Skeleton className="h-7 w-64" />
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           {Array.from({ length: 8 }).map((_, i) => (

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -12,7 +12,7 @@ export default async function SearchPage({ searchParams }: Props) {
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="w-full max-w-6xl p-4 flex flex-col gap-6">
+      <div className="w-full p-4 flex flex-col gap-6">
         <div className="flex flex-col gap-1">
           <h1 className="text-heading font-semibold">
             {query ? `「${query}」的搜尋結果` : "搜尋"}

--- a/app/vendor/layout.tsx
+++ b/app/vendor/layout.tsx
@@ -18,7 +18,7 @@ export default async function VendorLayout({ children }: { children: React.React
 
   return (
     <div className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
-      <div className="max-w-6xl w-full p-4 flex flex-col gap-4">
+      <div className="w-full p-4 flex flex-col gap-4">
         <nav className="flex gap-2">
           <Link href="/vendor/profile">
             <Button variant="outline" size="sm">店家資訊</Button>


### PR DESCRIPTION
## Summary
- 14 files: 移除 page-level `max-w-6xl` 上限，整版滿出視窗（保留 `p-4` 邊距）
- Dialogs (`sm:max-w-6xl`) **不動** — modal sizing 跟 page 不同 intent

## Test plan
- [x] `grep max-w-6xl` 只剩 2 個 Dialog 文件
- [x] Lint pass, 42 unit tests pass
- [ ] 視覺驗證：首頁 / search / menu / cart / orders / admin / vendor 都該整版

🤖 Generated with [Claude Code](https://claude.com/claude-code)