### PR TITLE
feat(db): auto-rollover daily_slots via pg_cron

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -66,6 +66,7 @@ types/
 - `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally; returns ranked items with `match_score` (tag_match × 10 + nutrition_sim × 2 + ln(trend+1) × 5 + open_bonus) and explainable `top_tag_label`. Cold-start safe: anonymous / no-history users degrade gracefully to trending + open.
 - `hybrid_search(p_query, p_query_embedding, p_area_id, p_limit)` — RRF (k=60) of pg_trgm keyword match + pgvector cosine semantic match. `p_query_embedding` 可為 NULL 讓 OpenAI 未配置時降級為 keyword-only。
 - `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean.
+- `rollover_daily_slots()` — SECURITY DEFINER; scheduled via pg_cron `rollover_daily_slots` job (`0 22 * * *` UTC = 06:00 Asia/Taipei). Materialises daily_slots for next 14 days from `menu_items.default_max_qty`, filtered by `vendors.is_active` + `vendors.operating_days` + `menu_items.is_available` + `default_max_qty > 0`. `ON CONFLICT (menu_item_id, date) DO NOTHING` preserves vendor's manual max_qty tweaks.
 
 ### Edge Functions
 - `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). Also generates `embedding` (text-embedding-3-small @ 512 dims) from name + ai_description + tag labels. 60s idempotency, max 100 items/invoke.
@@ -92,3 +93,6 @@ types/
 
 ### Slot-Limiting Mechanism
 `daily_slots.reserved_qty` is atomically updated by a Postgres trigger. `CHECK (reserved_qty <= max_qty)` prevents overselling.
+
+### Slot rollover (auto-provisioning)
+`rollover_daily_slots()` runs nightly (06:00 TPE) and on migration apply. Vendors only need to set `menu_items.default_max_qty` once; pg_cron auto-materialises the next 14 days of daily_slots respecting `vendor.operating_days`. Manual per-date max_qty overrides via the vendor bulk-slot dialog are preserved (`ON CONFLICT DO NOTHING`).

--- a/supabase/migrations/20260526084638_auto_rollover_daily_slots.sql
+++ b/supabase/migrations/20260526084638_auto_rollover_daily_slots.sql
@@ -1,0 +1,64 @@
+-- Auto-rollover daily_slots from menu_items.default_max_qty.
+--
+-- Before this migration, daily_slots rows were only created when a vendor
+-- explicitly hit the bulk-upsert dialog. Most vendors never did, so /menu/[id]
+-- rendered "本週已售完" for everything except the one vendor (大口漢堡) that
+-- actively maintained slots. This migration adds a nightly pg_cron job that
+-- materialises slots for the next 14 days from menu_items.default_max_qty,
+-- respecting vendor.operating_days. ON CONFLICT DO NOTHING preserves any
+-- manual max_qty tuning vendors have already applied to specific dates.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- SECURITY DEFINER bypasses daily_slots write RLS (owner-only).
+-- Inputs are public columns on menu_items + vendors; no data leak surface.
+CREATE OR REPLACE FUNCTION public.rollover_daily_slots()
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_inserted int;
+BEGIN
+  WITH date_series AS (
+    SELECT generate_series(CURRENT_DATE + 1, CURRENT_DATE + 14, '1 day'::interval)::date AS d
+  ),
+  candidate AS (
+    SELECT mi.id AS menu_item_id, ds.d AS date, mi.default_max_qty AS max_qty
+    FROM menu_items mi
+    JOIN vendors v ON v.id = mi.vendor_id
+    CROSS JOIN date_series ds
+    WHERE mi.is_available = true
+      AND mi.default_max_qty > 0
+      AND v.is_active = true
+      AND EXTRACT(DOW FROM ds.d)::int = ANY(v.operating_days)
+  ),
+  ins AS (
+    INSERT INTO daily_slots (menu_item_id, date, max_qty)
+    SELECT menu_item_id, date, max_qty FROM candidate
+    ON CONFLICT (menu_item_id, date) DO NOTHING
+    RETURNING 1
+  )
+  SELECT COUNT(*)::int INTO v_inserted FROM ins;
+
+  RETURN v_inserted;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rollover_daily_slots() FROM PUBLIC;
+
+-- Schedule daily at 22:00 UTC = 06:00 Asia/Taipei, before employees check menus.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'rollover_daily_slots') THEN
+    PERFORM cron.schedule(
+      'rollover_daily_slots',
+      '0 22 * * *',
+      $job$SELECT public.rollover_daily_slots();$job$
+    );
+  END IF;
+END $$;
+
+-- Immediate backfill so the fix takes effect the moment this migration applies.
+SELECT public.rollover_daily_slots();


### PR DESCRIPTION
## Summary
- 加 `rollover_daily_slots()` SECURITY DEFINER function + 每天 06:00 TPE pg_cron job，從 `menu_items.default_max_qty` 推未來 14 天 slot，吃 `vendor.operating_days` 過濾，`ON CONFLICT DO NOTHING` 保護手動微調
- 修「全部餐點顯示『本週已售完』」的問題：原本只有 1 家商家有 future-7d slot，套完 → 19 家全部有（28 → 894 row）
- 商家只要設一次 `default_max_qty` 就不用每週進後台 bulk-upsert

## Test plan
- [x] `mcp__supabase__apply_migration` 已套線上，立即 backfill 跑完
- [x] `SELECT COUNT(*) FROM daily_slots WHERE date > CURRENT_DATE AND date <= CURRENT_DATE + 7` 從 28 → 447
- [x] `cron.job` 出現 `rollover_daily_slots` row，schedule `0 22 * * *`，active=true
- [x] 19 家活躍商家全部有 future-7d slot（測試商家廚房 0 道菜，預期不出現）
- [ ] 開 `/menu/<vendor_id>` 確認「本週已售完」消失（待人工驗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)