### PR TITLE
fix: add vendor dashboard header link

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -53,6 +53,11 @@ export async function Header() {
             <Button variant="outline" size="sm">管理後台</Button>
           </Link>
         )}
+        {navigation.showVendorDashboard && (
+          <Link href="/vendor">
+            <Button variant="outline" size="sm">商家後台</Button>
+          </Link>
+        )}
         <ThemeToggle />
         {navigation.showOrders && (
           <Link href="/orders">

--- a/lib/navigation-rules.test.ts
+++ b/lib/navigation-rules.test.ts
@@ -29,6 +29,13 @@ describe("navigation rules", () => {
     expect(getHeaderNavigation(["vendor", "admin"])).toMatchObject({ showAdminDashboard: true });
   });
 
+  it("shows the vendor dashboard button for vendor accounts", () => {
+    expect(getHeaderNavigation(["user"])).toMatchObject({ showVendorDashboard: false });
+    expect(getHeaderNavigation(["vendor"])).toMatchObject({ showVendorDashboard: true });
+    expect(getHeaderNavigation(["user", "vendor"])).toMatchObject({ showVendorDashboard: true });
+    expect(getHeaderNavigation(["vendor", "admin"])).toMatchObject({ showVendorDashboard: true });
+  });
+
   it("shows employee features only for user role", () => {
     const employeeFeatures = { showAreaSelect: true, showSearch: true, showOrders: true, showCart: true };
     const hiddenFeatures = { showAreaSelect: false, showSearch: false, showOrders: false, showCart: false };

--- a/lib/navigation-rules.ts
+++ b/lib/navigation-rules.ts
@@ -7,9 +7,11 @@ export function getDefaultHomePath(roles: string[]) {
 export function getHeaderNavigation(roles: string[]) {
   const isAdmin = roles.includes("admin");
   const isUser = roles.includes("user");
+  const isVendor = roles.includes("vendor");
 
   return {
     showAdminDashboard: isAdmin,
+    showVendorDashboard: isVendor,
     showAreaSelect: isUser,
     showSearch: isUser,
     showOrders: isUser,


### PR DESCRIPTION
## Summary
- Add a vendor dashboard entry point to the global header for vendor accounts
- Extend header navigation rules with showVendorDashboard
- Add regression coverage for vendor dashboard visibility

## Test Plan
- bun run lint
- bun run test:unit
- bun run build