### PR TITLE
Fix header button visibility for different roles

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -44,8 +44,8 @@ export async function Header() {
         <Link href="/">
           <h1 className="text-heading font-semibold tracking-tight">NYCU <span className="text-brand">Eats</span></h1>
         </Link>
-        <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />
-        <SearchForm placeholderItems={placeholderItems} />
+        {navigation.showAreaSelect && <AreaSelect byCity={byCity} defaultAreaId={profile?.area_id ?? undefined} />}
+        {navigation.showSearch && <SearchForm placeholderItems={placeholderItems} />}
       </div>
       <div className="flex items-center gap-4">
         {navigation.showAdminDashboard && (

--- a/lib/navigation-rules.test.ts
+++ b/lib/navigation-rules.test.ts
@@ -29,14 +29,21 @@ describe("navigation rules", () => {
     expect(getHeaderNavigation(["vendor", "admin"])).toMatchObject({ showAdminDashboard: true });
   });
 
-  it("keeps cart and orders visible for all logged-in roles", () => {
-    expect(getHeaderNavigation(["user"])).toMatchObject({
-      showCart: true,
-      showOrders: true,
-    });
-    expect(getHeaderNavigation(["vendor"])).toMatchObject({
-      showCart: true,
-      showOrders: true,
-    });
+  it("shows employee features only for user role", () => {
+    const employeeFeatures = { showAreaSelect: true, showSearch: true, showOrders: true, showCart: true };
+    const hiddenFeatures = { showAreaSelect: false, showSearch: false, showOrders: false, showCart: false };
+
+    expect(getHeaderNavigation(["user"])).toMatchObject(employeeFeatures);
+    expect(getHeaderNavigation(["vendor"])).toMatchObject(hiddenFeatures);
+    expect(getHeaderNavigation(["admin"])).toMatchObject(hiddenFeatures);
+    expect(getHeaderNavigation([])).toMatchObject(hiddenFeatures);
+  });
+
+  it("preserves employee features when user also holds vendor or admin role", () => {
+    const employeeFeatures = { showAreaSelect: true, showSearch: true, showOrders: true, showCart: true };
+
+    expect(getHeaderNavigation(["user", "vendor"])).toMatchObject(employeeFeatures);
+    expect(getHeaderNavigation(["user", "admin"])).toMatchObject(employeeFeatures);
+    expect(getHeaderNavigation(["user", "vendor", "admin"])).toMatchObject(employeeFeatures);
   });
 });

--- a/lib/navigation-rules.ts
+++ b/lib/navigation-rules.ts
@@ -6,10 +6,13 @@ export function getDefaultHomePath(roles: string[]) {
 
 export function getHeaderNavigation(roles: string[]) {
   const isAdmin = roles.includes("admin");
+  const isUser = roles.includes("user");
 
   return {
     showAdminDashboard: isAdmin,
-    showCart: true,
-    showOrders: true,
+    showAreaSelect: isUser,
+    showSearch: isUser,
+    showOrders: isUser,
+    showCart: isUser,
   };
 }


### PR DESCRIPTION
## What

- Resolved the issue where buttons intended for users were visible to vendors and admins.

## Why

- Ensured that the header navigation displays the correct buttons based on user roles to enhance user experience and security.

## How to test

- Verify that the Area Select and Search buttons are only visible to users.
- Check that vendors and admins do not see the Area Select and Search buttons.
- Run the updated header navigation tests to confirm role-based visibility is functioning as expected.

