### PR TITLE
Fix vendor name selector in menu tests

### DIFF
--- a/e2e/menu.spec.ts
+++ b/e2e/menu.spec.ts
@@ -6,7 +6,7 @@ test.describe("菜單頁", () => {
     // Use the vendor grid (not recommendation section) to find vendor cards
     const vendorGrid = page.locator("main .grid");
     const firstVendor = vendorGrid.locator("a[href^='/menu/']").first();
-    const vendorName = await firstVendor.locator("p").first().textContent();
+    const vendorName = await firstVendor.locator("p.truncate").textContent();
     await firstVendor.click();
 
     await expect(page).toHaveURL(/\/menu\/.+/);


### PR DESCRIPTION
## What

- Corrected the selector used to retrieve the vendor name in the menu page tests.

## Why

- The previous implementation incorrectly targeted the first `<p>` element, which did not correspond to the vendor name. This caused inaccuracies in the test results.

## How to test

- Verify that the vendor name is now correctly fetched using the `p.truncate` selector.
- Run the menu page tests to ensure they pass with the updated selector.

