### PR TITLE
test: cover admin backend & vendor menu server actions

### DIFF
--- a/app/admin/actions.test.ts
+++ b/app/admin/actions.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+
+import { getDashboardStats, getTopMenuItems, getTopVendors } from "@/app/admin/actions";
+import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
+
+describe("getDashboardStats", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("requires the admin role", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("user")],
+    });
+    createClientMock.mockResolvedValue(client);
+    await expect(getDashboardStats()).rejects.toThrow("權限不足");
+  });
+
+  it("counts orders, sums confirmed/completed revenue, and derives rates", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        {
+          table: "orders",
+          result: {
+            data: [
+              { id: "o1", status: "completed", order_items: [{ qty: 2, unit_price: 50 }] },
+              { id: "o2", status: "confirmed", order_items: [{ qty: 1, unit_price: 30 }] },
+              { id: "o3", status: "cancelled", order_items: [{ qty: 1, unit_price: 999 }] },
+              { id: "o4", status: "completed", order_items: [{ qty: 1, unit_price: 20 }] },
+            ],
+          },
+        },
+        {
+          table: "orders",
+          result: {
+            data: [
+              { id: "l1", status: "completed", order_items: [{ qty: 1, unit_price: 100 }] },
+              { id: "l2", status: "confirmed", order_items: [{ qty: 2, unit_price: 25 }] },
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getDashboardStats()).resolves.toEqual({
+      thisMonth: { orders: 4, revenue: 150 }, // cancelled o3 excluded from revenue
+      lastMonth: { orders: 2, revenue: 150 },
+      completionRate: 0.5, // 2 completed / 4 total
+      cancelRate: 0.25, // 1 cancelled / 4 total
+    });
+  });
+
+  it("avoids divide-by-zero when there are no orders this month", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "orders", result: { data: [] } },
+        { table: "orders", result: { data: [] } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getDashboardStats()).resolves.toEqual({
+      thisMonth: { orders: 0, revenue: 0 },
+      lastMonth: { orders: 0, revenue: 0 },
+      completionRate: 0,
+      cancelRate: 0,
+    });
+  });
+});
+
+describe("getTopVendors", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("aggregates qty + revenue per vendor and respects the limit", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        {
+          table: "order_items",
+          result: {
+            data: [
+              { qty: 2, unit_price: 50, menu_items: { vendor_id: "v1", vendors: { name: "A" } } },
+              { qty: 1, unit_price: 10, menu_items: { vendor_id: "v1", vendors: { name: "A" } } },
+              { qty: 1, unit_price: 500, menu_items: { vendor_id: "v2", vendors: { name: "B" } } },
+              { qty: 9, unit_price: 9, menu_items: null }, // unjoined → skipped
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getTopVendors(1)).resolves.toEqual([{ name: "B", count: 1, revenue: 500 }]);
+  });
+});
+
+describe("getTopMenuItems", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("ranks menu items by revenue", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        {
+          table: "order_items",
+          result: {
+            data: [
+              { qty: 3, unit_price: 40, menu_item_id: "m1", menu_items: { name: "拉麵" } },
+              { qty: 1, unit_price: 40, menu_item_id: "m1", menu_items: { name: "拉麵" } },
+              { qty: 1, unit_price: 300, menu_item_id: "m2", menu_items: { name: "牛排" } },
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getTopMenuItems(5)).resolves.toEqual([
+      { name: "牛排", count: 1, revenue: 300 },
+      { name: "拉麵", count: 4, revenue: 160 },
+    ]);
+  });
+});

--- a/app/admin/reports/actions.test.ts
+++ b/app/admin/reports/actions.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+
+import { getMonthlyReport } from "@/app/admin/reports/actions";
+import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
+
+function orderItem(
+  qty: number,
+  unitPrice: number,
+  vendorId: string | null,
+  vendorName: string,
+  orderId: string | null,
+) {
+  return {
+    qty,
+    unit_price: unitPrice,
+    menu_items: vendorId ? { vendor_id: vendorId, vendors: { name: vendorName } } : null,
+    orders: orderId ? { id: orderId } : null,
+  };
+}
+
+describe("getMonthlyReport", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("requires the admin role", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("vendor")],
+    });
+    createClientMock.mockResolvedValue(client);
+    await expect(getMonthlyReport(2026, 5)).rejects.toThrow("權限不足");
+  });
+
+  it("sums revenue per vendor and counts distinct orders, sorted by revenue", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        {
+          table: "order_items",
+          result: {
+            data: [
+              orderItem(2, 50, "v1", "A", "o1"), // A: 100, order o1
+              orderItem(1, 30, "v1", "A", "o1"), // A: +30, same order o1
+              orderItem(1, 20, "v1", "A", "o2"), // A: +20, new order o2
+              orderItem(1, 500, "v2", "B", "o3"), // B: 500, order o3
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getMonthlyReport(2026, 5)).resolves.toEqual([
+      { vendor_id: "v2", vendor_name: "B", order_count: 1, total_revenue: 500 },
+      { vendor_id: "v1", vendor_name: "A", order_count: 2, total_revenue: 150 },
+    ]);
+  });
+
+  it("skips rows with missing vendor or order joins", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        {
+          table: "order_items",
+          result: {
+            data: [
+              orderItem(1, 100, null, "", "o1"), // no vendor → skipped
+              orderItem(1, 100, "v1", "A", null), // no order → skipped
+              orderItem(2, 40, "v1", "A", "o9"), // counted: 80
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getMonthlyReport(2026, 5)).resolves.toEqual([
+      { vendor_id: "v1", vendor_name: "A", order_count: 1, total_revenue: 80 },
+    ]);
+  });
+
+  it("returns an empty report when there are no qualifying items", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [roleProfile("admin"), { table: "order_items", result: { data: [] } }],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getMonthlyReport(2026, 5)).resolves.toEqual([]);
+  });
+});

--- a/app/admin/users/actions.test.ts
+++ b/app/admin/users/actions.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+
+import { grantVendorRole, revokeVendorRole } from "@/app/admin/users/actions";
+import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
+
+describe("admin user role actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+  });
+
+  it("requires the admin role", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("user")],
+    });
+    createClientMock.mockResolvedValue(client);
+    await expect(grantVendorRole("target")).rejects.toThrow("權限不足");
+  });
+
+  it("grants the vendor role to a plain user", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "profiles", result: { data: { role: ["user"] } } },
+        { table: "profiles", result: { error: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(grantVendorRole("target")).resolves.toEqual({ success: true });
+    expect(mutations).toEqual([
+      { table: "profiles", op: "update", payload: { role: ["user", "vendor"] } },
+    ]);
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/users");
+  });
+
+  it("is idempotent when the user is already a vendor", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "profiles", result: { data: { role: ["user", "vendor"] } } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(grantVendorRole("target")).resolves.toEqual({ success: true });
+    expect(mutations).toEqual([]);
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing target user on grant", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "profiles", result: { data: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(grantVendorRole("ghost")).resolves.toEqual({ error: "找不到使用者" });
+  });
+
+  it("revokes the vendor role while keeping other roles", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "profiles", result: { data: { role: ["user", "vendor"] } } },
+        { table: "profiles", result: { error: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(revokeVendorRole("target")).resolves.toEqual({ success: true });
+    expect(mutations).toEqual([
+      { table: "profiles", op: "update", payload: { role: ["user"] } },
+    ]);
+  });
+
+  it("reports a missing target user on revoke", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "profiles", result: { data: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(revokeVendorRole("ghost")).resolves.toEqual({ error: "找不到使用者" });
+  });
+});

--- a/app/admin/vendors/actions.test.ts
+++ b/app/admin/vendors/actions.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+
+import {
+  approveVendor,
+  reactivateVendor,
+  rejectVendor,
+  suspendVendor,
+  updateVendorAreas,
+} from "@/app/admin/vendors/actions";
+import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
+
+describe("admin vendor actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+  });
+
+  it("rejects callers who are not logged in", async () => {
+    const { client } = createSupabaseMock({ user: null, expectations: [] });
+    createClientMock.mockResolvedValue(client);
+    await expect(approveVendor("v1", [])).rejects.toThrow("未登入");
+  });
+
+  it("rejects callers without the admin role", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("user", "vendor")],
+    });
+    createClientMock.mockResolvedValue(client);
+    await expect(approveVendor("v1", [])).rejects.toThrow("權限不足");
+  });
+
+  it("approves a vendor and assigns the given areas", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "vendors", result: { error: null } },
+        { table: "vendor_areas", result: {} },
+        { table: "vendor_areas", result: {} },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(approveVendor("v1", ["a1", "a2"])).resolves.toEqual({ success: true });
+    expect(mutations).toEqual([
+      { table: "vendors", op: "update", payload: { status: "approved", is_active: true } },
+      { table: "vendor_areas", op: "delete", payload: undefined },
+      {
+        table: "vendor_areas",
+        op: "insert",
+        payload: [
+          { vendor_id: "v1", area_id: "a1" },
+          { vendor_id: "v1", area_id: "a2" },
+        ],
+      },
+    ]);
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/vendors");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/vendors/v1");
+  });
+
+  it("approves a vendor with no areas without inserting", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "vendors", result: { error: null } },
+        { table: "vendor_areas", result: {} },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(approveVendor("v1", [])).resolves.toEqual({ success: true });
+    expect(mutations.some((m) => m.op === "insert")).toBe(false);
+  });
+
+  it("surfaces an error and skips area writes when the update fails", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "vendors", result: { error: { message: "db down" } } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(approveVendor("v1", ["a1"])).resolves.toEqual({ error: "核准失敗" });
+    expect(mutations).toEqual([
+      { table: "vendors", op: "update", payload: { status: "approved", is_active: true } },
+    ]);
+  });
+
+  it("rejects a vendor", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [roleProfile("admin"), { table: "vendors", result: { error: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(rejectVendor("v1")).resolves.toEqual({ success: true });
+    expect(mutations).toEqual([
+      { table: "vendors", op: "update", payload: { status: "rejected", is_active: false } },
+    ]);
+  });
+
+  it("suspends an active vendor", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [roleProfile("admin"), { table: "vendors", result: { error: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(suspendVendor("v1")).resolves.toEqual({ success: true });
+    expect(mutations[0].payload).toEqual({ status: "suspended", is_active: false });
+  });
+
+  it("reactivates a suspended vendor", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [roleProfile("admin"), { table: "vendors", result: { error: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(reactivateVendor("v1")).resolves.toEqual({ success: true });
+    expect(mutations[0].payload).toEqual({ status: "approved", is_active: true });
+  });
+
+  it("replaces a vendor's areas atomically (delete then insert)", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        { table: "vendor_areas", result: {} },
+        { table: "vendor_areas", result: {} },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(updateVendorAreas("v1", ["a3"])).resolves.toEqual({ success: true });
+    expect(mutations).toEqual([
+      { table: "vendor_areas", op: "delete", payload: undefined },
+      { table: "vendor_areas", op: "insert", payload: [{ vendor_id: "v1", area_id: "a3" }] },
+    ]);
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/vendors/v1");
+  });
+});

--- a/app/cart/cart-view.test.ts
+++ b/app/cart/cart-view.test.ts
@@ -10,18 +10,21 @@ describe("buildCartViewModel", () => {
         date: "2026-04-02",
         qty: 1,
         unit_price: 80,
+        order_item_options: [],
       },
       {
         id: "item-1",
         date: "2026-04-01",
         qty: 2,
         unit_price: 100,
+        order_item_options: [],
       },
       {
         id: "item-3",
         date: "2026-04-01",
         qty: 3,
         unit_price: 50,
+        order_item_options: [],
       },
     ]);
 

--- a/app/vendor/menu/actions.test.ts
+++ b/app/vendor/menu/actions.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock, afterMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  afterMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+vi.mock("next/server", () => ({ after: afterMock }));
+
+import {
+  bulkUpsertSlots,
+  deleteMenuItem,
+  regenerateAiMetadata,
+  setDailySlot,
+} from "@/app/vendor/menu/actions";
+import { createSupabaseMock, roleProfile, type FromExpectation } from "@/test/supabase-mock";
+
+/** requireVendor() = requireRole("vendor") + a vendors row lookup. */
+function vendorContext(vendorId: string | null): FromExpectation[] {
+  return [
+    roleProfile("vendor"),
+    { table: "vendors", result: { data: vendorId ? { id: vendorId } : null } },
+  ];
+}
+
+describe("vendor menu actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+    afterMock.mockReset();
+  });
+
+  it("rejects a vendor without a store record", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: vendorContext(null),
+    });
+    createClientMock.mockResolvedValue(client);
+    await expect(setDailySlot("m1", "2026-05-27", 20)).rejects.toThrow("找不到商家");
+  });
+
+  describe("setDailySlot", () => {
+    it("upserts a slot for an item the vendor owns", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: { id: "m1" } } }, // ownership check
+          { table: "daily_slots", result: { error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(setDailySlot("m1", "2026-05-27", 20)).resolves.toEqual({ success: true });
+      expect(mutations).toEqual([
+        {
+          table: "daily_slots",
+          op: "upsert",
+          payload: { menu_item_id: "m1", date: "2026-05-27", max_qty: 20 },
+        },
+      ]);
+      expect(revalidatePathMock).toHaveBeenCalledWith("/vendor/menu");
+    });
+
+    it("blocks setting a slot on an item the vendor does not own", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: null } }, // not owned
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(setDailySlot("m1", "2026-05-27", 20)).rejects.toThrow("權限不足");
+      expect(mutations).toEqual([]); // never reached the upsert
+    });
+
+    it("surfaces the database error message", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: { id: "m1" } } },
+          { table: "daily_slots", result: { error: { message: "quota exceeded" } } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(setDailySlot("m1", "2026-05-27", 20)).resolves.toEqual({
+        error: "quota exceeded",
+      });
+    });
+  });
+
+  describe("bulkUpsertSlots", () => {
+    it("only upserts slots for items the vendor owns", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: [{ id: "m1" }, { id: "m2" }] } },
+          { table: "daily_slots", result: { error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      const result = await bulkUpsertSlots([
+        { menu_item_id: "m1", date: "2026-05-27", max_qty: 10 },
+        { menu_item_id: "m2", date: "2026-05-27", max_qty: 20 },
+        { menu_item_id: "m3", date: "2026-05-27", max_qty: 30 }, // not owned → dropped
+      ]);
+
+      expect(result).toEqual({ success: true, count: 2 });
+      expect(mutations[0].payload).toEqual([
+        { menu_item_id: "m1", date: "2026-05-27", max_qty: 10 },
+        { menu_item_id: "m2", date: "2026-05-27", max_qty: 20 },
+      ]);
+      // multi-area menu cache also revalidated
+      expect(revalidatePathMock).toHaveBeenCalledWith("/menu", "layout");
+    });
+
+    it("returns an error when none of the slots belong to the vendor", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [...vendorContext("v1"), { table: "menu_items", result: { data: [] } }],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(
+        bulkUpsertSlots([{ menu_item_id: "x", date: "2026-05-27", max_qty: 5 }]),
+      ).resolves.toEqual({ error: "沒有可建立的名額" });
+      expect(mutations).toEqual([]);
+    });
+  });
+
+  describe("deleteMenuItem", () => {
+    it("deletes an item scoped to the vendor", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [...vendorContext("v1"), { table: "menu_items", result: { error: null } }],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(deleteMenuItem("m1")).resolves.toEqual({ success: true });
+      expect(mutations).toEqual([{ table: "menu_items", op: "delete", payload: undefined }]);
+    });
+  });
+
+  describe("regenerateAiMetadata", () => {
+    it("rejects an empty selection", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: vendorContext("v1"),
+      });
+      createClientMock.mockResolvedValue(client);
+      await expect(regenerateAiMetadata([])).resolves.toEqual({ error: "請選擇至少一道餐點" });
+    });
+
+    it("rejects when none of the selected items are owned", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [...vendorContext("v1"), { table: "menu_items", result: { data: [] } }],
+      });
+      createClientMock.mockResolvedValue(client);
+      await expect(regenerateAiMetadata(["m1"])).resolves.toEqual({ error: "權限不足" });
+    });
+
+    it("invokes the edge function for owned items", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: [{ id: "m1" }] } },
+        ],
+        invokeResult: { data: { results: [{ id: "m1", status: "ok" }] }, error: null },
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(regenerateAiMetadata(["m1"])).resolves.toEqual({
+        results: [{ id: "m1", status: "ok" }],
+      });
+      expect(client.functions.invoke).toHaveBeenCalledWith("generate-menu-item-tags", {
+        body: { menu_item_ids: ["m1"], force: true },
+      });
+    });
+  });
+});

--- a/test/supabase-mock.ts
+++ b/test/supabase-mock.ts
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+/**
+ * Shared Supabase mock for Server Action unit tests.
+ *
+ * Models the PostgREST query builder as a thenable object so both terminal
+ * forms work: `.single()` / `.maybeSingle()` and bare `await from(...).update()`.
+ * `from(table)` consumes one expectation from an ordered queue, so a test
+ * declares the exact table-access sequence an action is expected to perform
+ * (including the `profiles` read inside `requireRole`).
+ */
+
+export type QueryResult = { data?: unknown; error?: unknown };
+export type FromExpectation = { table: string; result?: QueryResult };
+export type MutationOp = "insert" | "update" | "upsert" | "delete";
+export type MutationCapture = { table: string; op: MutationOp; payload?: unknown };
+
+const PASSTHROUGH = [
+  "select",
+  "eq",
+  "neq",
+  "in",
+  "is",
+  "gte",
+  "lte",
+  "order",
+  "limit",
+] as const;
+
+const MUTATIONS: MutationOp[] = ["insert", "update", "upsert", "delete"];
+
+export function createSupabaseMock({
+  user,
+  expectations,
+  invokeResult,
+}: {
+  user: { id: string } | null;
+  expectations: FromExpectation[];
+  invokeResult?: QueryResult;
+}) {
+  const queue = [...expectations];
+  const mutations: MutationCapture[] = [];
+  const fromOrder: string[] = [];
+
+  function makeBuilder(result: QueryResult, table: string) {
+    const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const m of PASSTHROUGH) builder[m] = vi.fn(() => builder as never);
+    for (const op of MUTATIONS) {
+      builder[op] = vi.fn((payload?: unknown) => {
+        mutations.push({ table, op, payload });
+        return builder as never;
+      });
+    }
+    builder.single = vi.fn(async () => result);
+    builder.maybeSingle = vi.fn(async () => result);
+    (builder as unknown as { then: (r: (v: QueryResult) => void) => Promise<void> }).then = (
+      resolve,
+    ) => Promise.resolve(result).then(resolve);
+    return builder;
+  }
+
+  const client = {
+    auth: { getUser: vi.fn(async () => ({ data: { user } })) },
+    from: vi.fn((table: string) => {
+      const exp = queue.shift();
+      if (!exp) throw new Error(`Unexpected from(${table}) — expectation queue is empty`);
+      if (exp.table !== table) {
+        throw new Error(`Expected from(${exp.table}), got from(${table})`);
+      }
+      fromOrder.push(table);
+      return makeBuilder(exp.result ?? {}, table);
+    }),
+    functions: {
+      invoke: vi.fn(async () => invokeResult ?? { data: { results: [] }, error: null }),
+    },
+  };
+
+  return { client, mutations, fromOrder };
+}
+
+/** `requireRole(role)` reads `profiles.role`; this is the expectation it consumes. */
+export function roleProfile(...roles: string[]): FromExpectation {
+  return { table: "profiles", result: { data: { role: roles } } };
+}


### PR DESCRIPTION
## Summary
- 為先前零測試的 admin 後台（商家審核 / 角色 / 月報表 / dashboard）與 vendor 菜單管理 Server Actions 補上單元測試
- 抽出共用 Supabase mock helper（`test/supabase-mock.ts`），消除各測試檔重複的 mock
- 修掉 main 既有的 `tsc` 失敗：cart-view 測試 fixture 補齊 `order_item_options`

## Test plan
- [x] `bun --bun run test:unit` → 76 tests passed (14 files)
- [x] `bun --bun x tsc --noEmit` → 無錯誤
- [x] `bun --bun run lint` → 無錯誤