### PR TITLE
feat(menu): rerank search results by natural-language intent

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -71,12 +71,13 @@ types/
 ### Edge Functions
 - `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). Also generates `embedding` (text-embedding-3-small @ 512 dims) from name + ai_description + tag labels. 60s idempotency, max 100 items/invoke.
 - `embed-query` — Search-time helper: embeds query string → returns 512-dim vector for `hybrid_search` RPC.
+- `rerank-search` — Search-time reranker: takes `hybrid_search` candidates + 原始 query，用 `gpt-5.4-mini` structured outputs 依「意圖契合度」(含「輕一點」→ 低熱量/低鈉偏好) 給每個候選 0~1 分。Online LLM call，與 `embed-query` 同 posture；caller (`lib/search.ts`) 視失敗為 best-effort 並降級回 RRF 順序。
 
 ### Recommendation pipeline (offline-only LLM)
 1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` + `embedding` (+ missing nutrition).
 2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile`.
 3. Home page calls `rank_menu_items_for_home` RPC → pure SQL ranking, no LLM in serving path.
-4. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) → results。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體。
+4. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
 
 ### Roles
 - `user` — Employee

--- a/lib/search.test.ts
+++ b/lib/search.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+
+import { searchHomeItems } from "@/lib/search";
+
+type Ranking = Array<{ id: string; score: number }>;
+
+function row(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: null,
+    price: 100,
+    image_url: null,
+    tags: [],
+    ai_tags: [],
+    ai_description: null,
+    calories: 500,
+    protein: 20,
+    sodium: 800,
+    vendor_id: "v1",
+    vendor_name: "店家",
+    vendor_is_open: true,
+    match_score: 0.03,
+    top_tag_label: null,
+  };
+}
+
+function makeClient(opts: {
+  embedding?: number[] | null;
+  embedError?: boolean;
+  rpcData?: ReturnType<typeof row>[] | null;
+  rpcError?: boolean;
+  ranking?: Ranking;
+  rerankError?: boolean;
+}) {
+  const invoke = vi.fn(async (name: string) => {
+    if (name === "embed-query") {
+      return opts.embedError
+        ? { data: null, error: { message: "no key" } }
+        : { data: { embedding: opts.embedding ?? [0.1, 0.2] }, error: null };
+    }
+    if (name === "rerank-search") {
+      return opts.rerankError
+        ? { data: null, error: { message: "llm down" } }
+        : { data: { ranking: opts.ranking ?? [] }, error: null };
+    }
+    return { data: null, error: null };
+  });
+
+  const rpc = vi.fn(async () =>
+    opts.rpcError
+      ? { data: null, error: { message: "rpc fail" } }
+      : { data: opts.rpcData ?? [], error: null },
+  );
+
+  return { client: { functions: { invoke }, rpc }, invoke, rpc };
+}
+
+describe("searchHomeItems", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("returns [] for a blank query without touching Supabase", async () => {
+    const { client, invoke, rpc } = makeClient({});
+    createClientMock.mockResolvedValue(client);
+
+    await expect(searchHomeItems("   ")).resolves.toEqual([]);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("over-fetches a candidate pool and reorders by rerank score", async () => {
+    const { client, invoke, rpc } = makeClient({
+      rpcData: [row("a", "A"), row("b", "B"), row("c", "C")], // RRF order A,B,C
+      ranking: [
+        { id: "c", score: 0.95 },
+        { id: "a", score: 0.4 },
+        { id: "b", score: 0.1 },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await searchHomeItems("我今天想吃輕一點的", "area1", 30);
+    expect(result.map((i) => i.id)).toEqual(["c", "a", "b"]);
+
+    // hybrid_search asked for the enlarged pool, not just the page size
+    expect(rpc).toHaveBeenCalledWith(
+      "hybrid_search",
+      expect.objectContaining({ p_limit: 40, p_area_id: "area1" }),
+    );
+    // reranker received the retrieved candidates
+    expect(invoke).toHaveBeenCalledWith(
+      "rerank-search",
+      expect.objectContaining({
+        body: expect.objectContaining({ query: "我今天想吃輕一點的" }),
+      }),
+    );
+  });
+
+  it("keeps the RRF order when the reranker fails", async () => {
+    const { client } = makeClient({
+      rpcData: [row("a", "A"), row("b", "B"), row("c", "C")],
+      rerankError: true,
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await searchHomeItems("牛肉麵");
+    expect(result.map((i) => i.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("places rerank-omitted items after scored ones", async () => {
+    const { client } = makeClient({
+      rpcData: [row("a", "A"), row("b", "B"), row("c", "C")],
+      ranking: [{ id: "b", score: 0.8 }], // only b scored
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await searchHomeItems("清爽");
+    expect(result[0].id).toBe("b"); // scored item first
+    expect(result.map((i) => i.id).slice(1)).toEqual(["a", "c"]); // others keep order
+  });
+
+  it("degrades to keyword-only embedding when embed-query fails", async () => {
+    const { client, rpc } = makeClient({
+      embedError: true,
+      rpcData: [row("a", "A")],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await searchHomeItems("拉麵");
+    expect(rpc).toHaveBeenCalledWith(
+      "hybrid_search",
+      expect.objectContaining({ p_query_embedding: null }),
+    );
+  });
+
+  it("skips the reranker when there is at most one candidate", async () => {
+    const { client, invoke } = makeClient({ rpcData: [row("a", "A")] });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await searchHomeItems("便當");
+    expect(result.map((i) => i.id)).toEqual(["a"]);
+    expect(invoke).not.toHaveBeenCalledWith("rerank-search", expect.anything());
+  });
+
+  it("returns [] when hybrid_search errors", async () => {
+    const { client } = makeClient({ rpcError: true });
+    createClientMock.mockResolvedValue(client);
+    await expect(searchHomeItems("漢堡")).resolves.toEqual([]);
+  });
+});

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,6 +1,12 @@
 import type { HomeItem } from "@/lib/recommendation";
 import { createClient } from "@/lib/supabase/server";
 
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+// Over-fetch a candidate pool from hybrid_search so the reranker has room to
+// reorder; the final result is sliced back down to `limit`.
+const RERANK_POOL = 40;
+
 export async function searchHomeItems(
   query: string,
   areaId?: string,
@@ -23,15 +29,16 @@ export async function searchHomeItems(
     console.error("embed-query failed; degrading to keyword-only:", e);
   }
 
+  // Step 2: retrieve a candidate pool via hybrid_search (keyword + semantic RRF).
   const { data, error } = await supabase.rpc("hybrid_search", {
     p_query: trimmed,
     p_query_embedding: embedding as unknown as string,
     p_area_id: areaId ?? undefined,
-    p_limit: limit,
+    p_limit: Math.max(limit, RERANK_POOL),
   });
   if (error || !data) return [];
 
-  return data.map((row) => ({
+  const items: HomeItem[] = data.map((row) => ({
     id: row.id,
     name: row.name,
     description: row.description,
@@ -49,4 +56,51 @@ export async function searchHomeItems(
     match_score: row.match_score,
     top_tag_label: row.top_tag_label,
   }));
+
+  // Step 3: LLM rerank by natural-language intent. Best-effort — any failure
+  // keeps the original RRF order.
+  const reranked = await rerankItems(supabase, trimmed, items);
+  return (reranked ?? items).slice(0, limit);
+}
+
+async function rerankItems(
+  supabase: SupabaseServerClient,
+  query: string,
+  items: HomeItem[],
+): Promise<HomeItem[] | null> {
+  if (items.length <= 1) return null;
+
+  try {
+    const candidates = items.map((i) => ({
+      id: i.id,
+      name: i.name,
+      description: i.ai_description ?? i.description,
+      tags: i.tags,
+      calories: i.calories,
+      protein: i.protein,
+      sodium: i.sodium,
+    }));
+
+    const { data, error } = await supabase.functions.invoke<{
+      ranking: Array<{ id: string; score: number }>;
+    }>("rerank-search", { body: { query, candidates } });
+
+    if (error || !data?.ranking?.length) return null;
+
+    const scoreById = new Map(data.ranking.map((r) => [r.id, r.score]));
+
+    // Reorder by rerank score (desc); items the reranker omitted keep their
+    // relative RRF order at the tail. Array.sort is stable in modern engines.
+    return [...items].sort((a, b) => {
+      const sa = scoreById.get(a.id);
+      const sb = scoreById.get(b.id);
+      if (sa == null && sb == null) return 0;
+      if (sa == null) return 1;
+      if (sb == null) return -1;
+      return sb - sa;
+    });
+  } catch (e) {
+    console.error("rerank-search failed; keeping RRF order:", e);
+    return null;
+  }
 }

--- a/supabase/functions/rerank-search/deno.json
+++ b/supabase/functions/rerank-search/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "openai": "npm:openai@4"
+  }
+}

--- a/supabase/functions/rerank-search/index.ts
+++ b/supabase/functions/rerank-search/index.ts
@@ -1,0 +1,149 @@
+// rerank-search
+//
+// Search-time reranker. Takes the candidate set returned by `hybrid_search`
+// (embedding + keyword RRF retrieval) and reorders it by how well each item
+// matches the user's natural-language intent — including implicit health /
+// portion preferences ("我今天想吃輕一點的" → favour light, low-calorie items).
+//
+// Online LLM call, same posture as `embed-query`. Caller (lib/search.ts) treats
+// any failure as best-effort and falls back to the original RRF order.
+//
+// Required secret: OPENAI_API_KEY
+// Optional: OPENAI_RERANK_MODEL (default OPENAI_MODEL, default "gpt-5.4-mini")
+
+import OpenAI from "npm:openai@4";
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")!;
+const OPENAI_MODEL =
+  Deno.env.get("OPENAI_RERANK_MODEL") ?? Deno.env.get("OPENAI_MODEL") ?? "gpt-5.4-mini";
+
+const MAX_QUERY_CHARS = 500;
+const MAX_CANDIDATES = 50;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+interface Candidate {
+  id: string;
+  name: string;
+  description?: string | null;
+  tags?: string[];
+  calories?: number | null;
+  protein?: number | null;
+  sodium?: number | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: CORS_HEADERS });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ error: "missing auth" }, 401);
+
+  let payload: { query?: unknown; candidates?: unknown };
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+
+  const query = typeof payload.query === "string" ? payload.query.trim() : "";
+  if (!query) return json({ error: "query required" }, 400);
+  if (query.length > MAX_QUERY_CHARS) {
+    return json({ error: `query too long (>${MAX_QUERY_CHARS} chars)` }, 400);
+  }
+
+  if (!Array.isArray(payload.candidates) || payload.candidates.length === 0) {
+    return json({ error: "candidates required" }, 400);
+  }
+  const candidates = (payload.candidates as Candidate[])
+    .filter((c) => c && typeof c.id === "string" && typeof c.name === "string")
+    .slice(0, MAX_CANDIDATES);
+  if (candidates.length === 0) return json({ error: "no valid candidates" }, 400);
+
+  const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+  try {
+    const completion = await openai.chat.completions.create({
+      model: OPENAI_MODEL,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: buildUserPrompt(query, candidates) },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "rerank",
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              ranking: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    id: { type: "string" },
+                    score: { type: "number" },
+                  },
+                  required: ["id", "score"],
+                },
+              },
+            },
+            required: ["ranking"],
+          },
+          strict: true,
+        },
+      },
+    });
+
+    const content = completion.choices?.[0]?.message?.content;
+    if (!content) return json({ error: "empty completion content" }, 500);
+
+    const parsed = JSON.parse(content) as { ranking?: Array<{ id: string; score: number }> };
+    const knownIds = new Set(candidates.map((c) => c.id));
+    const ranking = (parsed.ranking ?? []).filter((r) => knownIds.has(r.id));
+    return json({ ranking }, 200);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return json({ error: message }, 500);
+  }
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+const SYSTEM_PROMPT = `你是台灣校園訂餐平台的搜尋重排助手。使用者用自然語言描述今天想吃什麼，你要為每個候選餐點打 0~1 的「意圖契合度」分數（1=非常契合，0=完全不契合）。
+
+評分依據：
+- 口味 / 餐點類型是否符合使用者描述。
+- 隱含的健康與份量偏好：「輕一點 / 清爽 / 健康」偏好低熱量、低鈉、蔬食或湯品；「吃飽一點 / 重口味」偏好高熱量、高蛋白、份量足的餐點。
+- 依語意判斷，不要只因菜名字面與查詢字串相近就給高分。
+
+為傳入的每一個候選 id 都輸出一個分數。`;
+
+function buildUserPrompt(query: string, candidates: Candidate[]): string {
+  return JSON.stringify({
+    query,
+    candidates: candidates.map((c) => ({
+      id: c.id,
+      name: c.name,
+      description: c.description ?? null,
+      tags: c.tags ?? [],
+      calories: c.calories ?? null,
+      protein: c.protein ?? null,
+      sodium: c.sodium ?? null,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- 在 embedding 檢索之後加入 **LLM rerank 階段**：自然語言查詢（如「我今天想吃輕一點的」）會依「意圖契合度」重排，而不只是 keyword + 向量的 RRF 融合
- 新增 edge function `rerank-search`（`gpt-5.4-mini` structured outputs，0~1 分，含「輕一點」→ 低熱量/低鈉的隱含偏好）
- `lib/search.ts`：過度檢索候選池 (40) → rerank → 取前 `limit`；rerank/embed 失敗時 best-effort 降級回 RRF / keyword-only 順序
- 補上 `lib/search.test.ts`（先前 search 路徑零測試）
- `architecture.md` 更新搜尋 pipeline 說明

## Test plan
- [x] `bun --bun run test:unit` → 85 tests passed (15 files)
- [x] `bun --bun x tsc --noEmit` → 無錯誤
- [x] `bun --bun run lint` → 無錯誤

## 部署備註
`rerank-search` 是新的 Supabase Edge Function，需要部署才會生效：
`supabase functions deploy rerank-search`（沿用既有的 `OPENAI_API_KEY` secret；可選 `OPENAI_RERANK_MODEL`）。未部署時 `lib/search.ts` 會自動降級回 RRF 順序，不會壞。