### PR TITLE
feat(ui): 首頁「今天吃什麼」隨機推薦輪盤

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { FoodWheel } from "@/components/food-wheel";
 import { HomeItemCard } from "@/components/home-item-card";
 import RecommendationSection from "@/components/recommendation-section";
 import { getHomeItems, getTrendingItems } from "@/lib/recommendation";
@@ -39,19 +40,23 @@ export default async function HomePage({ searchParams }: Props) {
           <RecommendationSection title="🔥 熱銷排行" items={trending} accent />
         )}
 
-        {items.length === 0 ? (
-          <p className="text-muted-foreground text-center py-16">
-            {area ? "此校區目前沒有可預訂的餐點" : "請先選擇校區"}
-          </p>
+        {items.length === 0 && !area ? (
+          <p className="text-muted-foreground text-center py-16">請先選擇校區</p>
         ) : (
-          <section className="flex flex-col gap-3">
-            <h2 className="text-heading font-semibold">所有餐點</h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {items.map((item) => (
-                <HomeItemCard key={item.id} item={item} />
-              ))}
-            </div>
-          </section>
+          <>
+            <FoodWheel items={items} />
+
+            {items.length > 0 && (
+              <section className="flex flex-col gap-3">
+                <h2 className="text-heading font-semibold">所有餐點</h2>
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                  {items.map((item) => (
+                    <HomeItemCard key={item.id} item={item} />
+                  ))}
+                </div>
+              </section>
+            )}
+          </>
         )}
       </div>
     </main>

--- a/components/food-wheel.tsx
+++ b/components/food-wheel.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { HomeItemCard } from "@/components/home-item-card";
+import { Button } from "@/components/ui/button";
+import type { HomeItem } from "@/lib/recommendation";
+import { pickRandomItem } from "@/lib/roulette";
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  items: HomeItem[];
+}
+
+const SPIN_MS = 1300;
+
+export function FoodWheel({ items }: Props) {
+  const [result, setResult] = useState<HomeItem | null>(null);
+  const [preview, setPreview] = useState<HomeItem | null>(null);
+  const [rolling, setRolling] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => clearTimeout(timer.current ?? undefined), []);
+
+  function reducedMotion() {
+    return (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  }
+
+  function spin() {
+    if (items.length === 0 || rolling) return;
+    setResult(null);
+
+    if (reducedMotion()) {
+      setResult(pickRandomItem(items));
+      return;
+    }
+
+    setRolling(true);
+    const start = Date.now();
+    let delay = 60;
+
+    const tick = () => {
+      setPreview(pickRandomItem(items));
+      if (Date.now() - start < SPIN_MS) {
+        delay += 16; // decelerate
+        timer.current = setTimeout(tick, delay);
+      } else {
+        setRolling(false);
+        setResult(pickRandomItem(items));
+      }
+    };
+    tick();
+  }
+
+  // Empty state — never spin an empty plate.
+  if (items.length === 0) {
+    return (
+      <section className="flex flex-col gap-3">
+        <h2 className="text-heading font-semibold">🎲 今天吃什麼</h2>
+        <div className="border rounded-card bg-card p-8 text-center text-muted-foreground">
+          這個校區今天還沒有可選的餐點，換個校區或晚點再來看看 🍽️
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-heading font-semibold">🎲 今天吃什麼</h2>
+      <div className="border rounded-card bg-card p-4 flex flex-col items-center gap-4">
+        <div className="w-full max-w-xs">
+          {result && !rolling ? (
+            <HomeItemCard item={result} />
+          ) : rolling ? (
+            <div className="h-44 flex items-center justify-center text-center">
+              <p className="text-heading font-semibold animate-pulse line-clamp-2">
+                {preview?.name ?? "…"}
+              </p>
+            </div>
+          ) : (
+            <div className="h-44 flex items-center justify-center text-center text-muted-foreground">
+              <p>選擇困難？讓骰子幫你決定今天的午餐</p>
+            </div>
+          )}
+        </div>
+        <Button onClick={spin} disabled={rolling} className="self-center">
+          {rolling ? "選擇中…" : result ? "再轉一次" : "🎲 幫我選一個"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/lib/roulette.test.ts
+++ b/lib/roulette.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { pickRandomItem } from "@/lib/roulette";
+
+describe("pickRandomItem", () => {
+  it("returns null for an empty pool", () => {
+    expect(pickRandomItem([])).toBeNull();
+  });
+
+  it("returns the only item for a single-element pool", () => {
+    expect(pickRandomItem(["a"], () => 0.99)).toBe("a");
+  });
+
+  it("maps rand() across the index range", () => {
+    const items = ["a", "b", "c", "d"];
+    expect(pickRandomItem(items, () => 0)).toBe("a");
+    expect(pickRandomItem(items, () => 0.5)).toBe("c");
+    expect(pickRandomItem(items, () => 0.999)).toBe("d");
+  });
+
+  it("never overflows when rand() returns 1", () => {
+    const items = ["a", "b", "c"];
+    expect(pickRandomItem(items, () => 1)).toBe("c");
+  });
+});

--- a/lib/roulette.ts
+++ b/lib/roulette.ts
@@ -1,0 +1,9 @@
+/**
+ * Pick a uniformly random element. `rand` is injectable so the choice is
+ * deterministic in tests. Returns null for an empty pool.
+ */
+export function pickRandomItem<T>(items: T[], rand: () => number = Math.random): T | null {
+  if (items.length === 0) return null;
+  const index = Math.min(items.length - 1, Math.floor(rand() * items.length));
+  return items[index];
+}


### PR DESCRIPTION
## Summary
- 首頁推薦區新增 **🎲 今天吃什麼** 隨機推薦輪盤：從該校區既有可選餐點隨機挑一道，減速動畫後落在結果卡（複用 `HomeItemCard`，可點進菜單）
- 純前端呈現 + 既有 `getHomeItems` query —— 無新 migration、無線上 LLM
- 候選為空時顯示 empty state，不會轉一個空盤
- 尊重 `prefers-reduced-motion`（直接給結果不跑動畫）
- 抽出純函式 `lib/roulette.ts`（`rand` 可注入）並加單元測試

## Test plan
- [x] `bun --bun run test:unit` → 89 tests passed (16 files)
- [x] `bun --bun x tsc --noEmit` → 無錯誤
- [x] `bun --bun run lint` → 無錯誤
- [ ] CI `lint-and-build`（next build）通過