### PR TITLE
Sync Google display name to profile on OAuth callback

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -9,8 +9,12 @@ export async function GET(request: Request) {
 
   if (code) {
     const supabase = await createClient();
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (!error) {
+    const { data: { user }, error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error && user) {
+      const name = user.user_metadata?.full_name ?? user.user_metadata?.name;
+      if (name) {
+        await supabase.from("profiles").update({ name }).eq("id", user.id).is("name", null);
+      }
       return NextResponse.redirect(`${origin}${next}`);
     }
   }

--- a/supabase/migrations/20260526160000_fix_handle_new_user_name.sql
+++ b/supabase/migrations/20260526160000_fix_handle_new_user_name.sql
@@ -1,0 +1,15 @@
+-- Fix handle_new_user to fallback to 'name' key when 'full_name' is absent.
+-- Google OAuth populates both, but some providers only set one.
+create or replace function handle_new_user()
+returns trigger language plpgsql security definer as $$
+begin
+  insert into profiles (id, name, email, avatar_url)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'name'),
+    new.email,
+    new.raw_user_meta_data->>'avatar_url'
+  );
+  return new;
+end;
+$$;


### PR DESCRIPTION
## What

- Existing users with a null profile name now receive their Google display name upon OAuth callback.
- New accounts are covered regardless of which key the OAuth provider populates.

## Why

- Ensures that user profiles are accurately populated with display names from Google OAuth, improving user experience and data consistency.

## How to test

- Perform OAuth login with a Google account that has a display name.
- Verify that the profile name is updated correctly in the database.
- Test with new accounts to ensure fallback to the 'name' key works as intended.

