### PR TITLE
feat(db): semantic user vector + MMR diversity for home ranking

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -61,11 +61,12 @@ types/
 - `tag_vocabulary` — Controlled-vocab AI tags (42 slugs × 6 axes); `validate_ai_tags` trigger enforces `menu_items.ai_tags ⊆ tag_vocabulary.slug`
 - `user_tag_preferences` — Per-user tag affinity score, accumulated on order confirm
 - `user_nutrition_profile` — Per-user running average consumption (calories/protein/sodium/sugar)
+- `user_embeddings` — Per-user 512-dim taste vector (mean of confirmed items' embeddings); recomputed on every confirm
 
 ### DB Functions
-- `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally; returns ranked items with `match_score` (tag_match × 10 + nutrition_sim × 2 + ln(trend+1) × 5 + open_bonus) and explainable `top_tag_label`. Cold-start safe: anonymous / no-history users degrade gracefully to trending + open.
+- `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally. Three-factor z-score normalised ranking: (a) cosine sim between `user_embeddings.embedding` and `menu_items.embedding`, (b) nutrition profile similarity, (c) ln(7-day trend). Plus `+0.5` open-vendor bonus. Top `limit × 3` candidate pool then reranked by MMR (λ = 0.7) for diversity. Cold-start (no user vector) → z_user clamps to 0, trend + nutrition + open drive ranking. Returns `match_score` + explainable `top_tag_label`.
 - `hybrid_search(p_query, p_query_embedding, p_area_id, p_limit)` — RRF (k=60) of pg_trgm keyword match + pgvector cosine semantic match. `p_query_embedding` 可為 NULL 讓 OpenAI 未配置時降級為 keyword-only。
-- `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean.
+- `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean + recomputes user embedding (full re-mean over all confirmed items).
 - `rollover_daily_slots()` — SECURITY DEFINER; scheduled via pg_cron `rollover_daily_slots` job (`0 22 * * *` UTC = 06:00 Asia/Taipei). Materialises daily_slots for next 14 days from `menu_items.default_max_qty`, filtered by `vendors.is_active` + `vendors.operating_days` + `menu_items.is_available` + `default_max_qty > 0`. `ON CONFLICT (menu_item_id, date) DO NOTHING` preserves vendor's manual max_qty tweaks.
 
 ### Edge Functions
@@ -75,8 +76,8 @@ types/
 
 ### Recommendation pipeline (offline-only LLM)
 1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` + `embedding` (+ missing nutrition).
-2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile`.
-3. Home page calls `rank_menu_items_for_home` RPC → pure SQL ranking, no LLM in serving path.
+2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile` + `user_embeddings`.
+3. Home page calls `rank_menu_items_for_home` RPC → semantic cosine + nutrition + trend with z-score normalised weights and MMR diversity rerank; no LLM in serving path.
 4. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
 
 ### Roles

--- a/supabase/migrations/20260526141701_embedding_recsys_engine.sql
+++ b/supabase/migrations/20260526141701_embedding_recsys_engine.sql
@@ -1,0 +1,350 @@
+-- Recommendation engine upgrade — PR #1 of 4.
+--
+-- Replaces the linear tag-match × 10 + nutrition × 2 + log(trend) × 5 ranking
+-- with three improvements:
+--
+--   1. Semantic user vector — aggregate the embeddings of the items each user
+--      has confirmed. Recommend = cosine similarity against menu_items.embedding.
+--      This learns continuous taste, not just 42 discrete tag slugs.
+--
+--   2. Z-score normalisation — raw factors (user_sim, nutrition_sim, ln(trend))
+--      live on wildly different scales, so the old × 10 / × 5 / × 2 weights had
+--      no real meaning. Normalising each factor in the candidate pool lets the
+--      coefficients actually mean "1× as influential".
+--
+--   3. MMR diversity rerank — top of the pool reranked with Maximal Marginal
+--      Relevance (λ = 0.7). Stops the homepage filling up with five variants
+--      of the same dish.
+--
+-- Cold-start (anonymous / no orders) degrades gracefully: user vector NULL →
+-- z_user clamps to 0 → trend + nutrition + open_bonus drive the ranking.
+
+-- =====================================================================
+-- 1. user_embeddings — materialised mean of confirmed items' embeddings
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS user_embeddings (
+  user_id    uuid PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  embedding  vector(512) NOT NULL,
+  n_orders   int NOT NULL DEFAULT 0,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_embeddings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_embeddings_read_own" ON user_embeddings;
+CREATE POLICY "user_embeddings_read_own" ON user_embeddings
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+-- =====================================================================
+-- 2. Extend confirm trigger to also recompute user_embeddings
+--    Full recompute (not incremental) — per-user order volume is small and
+--    avoids floating-point drift across many incremental updates.
+-- =====================================================================
+CREATE OR REPLACE FUNCTION update_user_preferences_on_confirm()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM 'confirmed' OR OLD.status = 'confirmed' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Tag preferences (unchanged from before)
+  INSERT INTO user_tag_preferences (user_id, tag_slug, score, last_event_at)
+  SELECT
+    NEW.user_id,
+    tag,
+    SUM(oi.qty)::numeric,
+    now()
+  FROM order_items oi
+  JOIN menu_items mi ON mi.id = oi.menu_item_id
+  CROSS JOIN LATERAL unnest(mi.ai_tags) AS t(tag)
+  WHERE oi.order_id = NEW.id
+  GROUP BY tag
+  ON CONFLICT (user_id, tag_slug) DO UPDATE
+    SET score = user_tag_preferences.score + EXCLUDED.score,
+        last_event_at = now();
+
+  -- Nutrition profile (unchanged)
+  WITH order_avg AS (
+    SELECT
+      AVG(mi.calories::numeric) FILTER (WHERE mi.calories IS NOT NULL) AS calories,
+      AVG(mi.protein) FILTER (WHERE mi.protein IS NOT NULL) AS protein,
+      AVG(mi.sodium)  FILTER (WHERE mi.sodium IS NOT NULL)  AS sodium,
+      AVG(mi.sugar)   FILTER (WHERE mi.sugar IS NOT NULL)   AS sugar,
+      COUNT(*) AS n
+    FROM order_items oi
+    JOIN menu_items mi ON mi.id = oi.menu_item_id
+    WHERE oi.order_id = NEW.id
+  )
+  INSERT INTO user_nutrition_profile
+    (user_id, avg_calories, avg_protein, avg_sodium, avg_sugar, sample_count, last_event_at)
+  SELECT NEW.user_id, calories, protein, sodium, sugar, n, now()
+  FROM order_avg
+  WHERE n > 0
+  ON CONFLICT (user_id) DO UPDATE
+    SET
+      avg_calories = CASE
+        WHEN EXCLUDED.avg_calories IS NULL THEN user_nutrition_profile.avg_calories
+        WHEN user_nutrition_profile.avg_calories IS NULL THEN EXCLUDED.avg_calories
+        ELSE (user_nutrition_profile.avg_calories * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_calories * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      avg_protein = CASE
+        WHEN EXCLUDED.avg_protein IS NULL THEN user_nutrition_profile.avg_protein
+        WHEN user_nutrition_profile.avg_protein IS NULL THEN EXCLUDED.avg_protein
+        ELSE (user_nutrition_profile.avg_protein * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_protein * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      avg_sodium = CASE
+        WHEN EXCLUDED.avg_sodium IS NULL THEN user_nutrition_profile.avg_sodium
+        WHEN user_nutrition_profile.avg_sodium IS NULL THEN EXCLUDED.avg_sodium
+        ELSE (user_nutrition_profile.avg_sodium * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_sodium * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      avg_sugar = CASE
+        WHEN EXCLUDED.avg_sugar IS NULL THEN user_nutrition_profile.avg_sugar
+        WHEN user_nutrition_profile.avg_sugar IS NULL THEN EXCLUDED.avg_sugar
+        ELSE (user_nutrition_profile.avg_sugar * user_nutrition_profile.sample_count
+              + EXCLUDED.avg_sugar * EXCLUDED.sample_count)
+             / (user_nutrition_profile.sample_count + EXCLUDED.sample_count)
+      END,
+      sample_count = user_nutrition_profile.sample_count + EXCLUDED.sample_count,
+      last_event_at = now();
+
+  -- NEW: recompute user embedding (mean of all confirmed items' embeddings)
+  INSERT INTO user_embeddings (user_id, embedding, n_orders, updated_at)
+  SELECT
+    NEW.user_id,
+    AVG(mi.embedding)::vector(512),
+    COUNT(*)::int,
+    now()
+  FROM order_items oi
+  JOIN orders o ON o.id = oi.order_id
+  JOIN menu_items mi ON mi.id = oi.menu_item_id
+  WHERE o.user_id = NEW.user_id
+    AND o.status IN ('confirmed', 'completed')
+    AND mi.embedding IS NOT NULL
+  HAVING COUNT(*) > 0
+  ON CONFLICT (user_id) DO UPDATE
+    SET embedding = EXCLUDED.embedding,
+        n_orders = EXCLUDED.n_orders,
+        updated_at = now();
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION update_user_preferences_on_confirm() FROM PUBLIC;
+
+-- =====================================================================
+-- 3. Backfill user_embeddings from existing confirmed orders
+-- =====================================================================
+INSERT INTO user_embeddings (user_id, embedding, n_orders, updated_at)
+SELECT
+  o.user_id,
+  AVG(mi.embedding)::vector(512),
+  COUNT(*)::int,
+  now()
+FROM order_items oi
+JOIN orders o ON o.id = oi.order_id
+JOIN menu_items mi ON mi.id = oi.menu_item_id
+WHERE o.status IN ('confirmed', 'completed')
+  AND mi.embedding IS NOT NULL
+GROUP BY o.user_id
+HAVING COUNT(*) > 0
+ON CONFLICT (user_id) DO UPDATE
+  SET embedding = EXCLUDED.embedding,
+      n_orders = EXCLUDED.n_orders,
+      updated_at = now();
+
+-- =====================================================================
+-- 4. Rewrite rank_menu_items_for_home with semantic + z-norm + MMR
+-- =====================================================================
+CREATE OR REPLACE FUNCTION rank_menu_items_for_home(
+  p_area_id uuid DEFAULT NULL,
+  p_limit   int  DEFAULT 60
+)
+RETURNS TABLE (
+  id              uuid,
+  name            text,
+  description     text,
+  price           numeric,
+  image_url       text,
+  ai_tags         text[],
+  ai_description  text,
+  tags            text[],
+  calories        int,
+  protein         numeric,
+  sodium          numeric,
+  vendor_id       uuid,
+  vendor_name     text,
+  vendor_is_open  boolean,
+  match_score     numeric,
+  top_tag_label   text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_user_id   uuid := (SELECT auth.uid());
+  v_user_vec  vector(512);
+  v_nutr      record;
+  v_lambda    numeric := 0.7;
+  v_pool_size int := GREATEST(p_limit * 3, 30);
+  v_selected  uuid[] := ARRAY[]::uuid[];
+  v_pick      uuid;
+BEGIN
+  SELECT ue.embedding INTO v_user_vec
+  FROM user_embeddings ue WHERE ue.user_id = v_user_id;
+
+  SELECT * INTO v_nutr
+  FROM user_nutrition_profile WHERE user_id = v_user_id;
+
+  -- Candidate pool: raw 3 factors → z-score normalise → blended score → top N
+  DROP TABLE IF EXISTS _rank_cand;
+  CREATE TEMP TABLE _rank_cand ON COMMIT DROP AS
+  WITH trending AS (
+    SELECT oi.menu_item_id, SUM(oi.qty)::numeric AS recent_qty
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    WHERE o.status IN ('confirmed','completed')
+      AND o.created_at > now() - interval '7 days'
+    GROUP BY oi.menu_item_id
+  ),
+  raw AS (
+    SELECT
+      mi.id,
+      mi.embedding,
+      v.is_open,
+      CASE
+        WHEN v_user_vec IS NOT NULL AND mi.embedding IS NOT NULL
+        THEN (1.0 - (mi.embedding <=> v_user_vec))::numeric
+        ELSE 0::numeric
+      END AS raw_user_sim,
+      CASE
+        WHEN v_nutr.sample_count IS NOT NULL THEN
+          1.0 / (
+            1.0
+            + COALESCE(ABS(mi.calories - v_nutr.avg_calories) / 100.0, 0)
+            + COALESCE(ABS(mi.protein  - v_nutr.avg_protein)  / 10.0,  0)
+            + COALESCE(ABS(mi.sodium   - v_nutr.avg_sodium)   / 200.0, 0)
+          )
+        ELSE 0::numeric
+      END AS raw_nutr_sim,
+      LN(1 + COALESCE(t.recent_qty, 0))::numeric AS raw_trend
+    FROM menu_items mi
+    JOIN vendors v ON v.id = mi.vendor_id
+    LEFT JOIN trending t ON t.menu_item_id = mi.id
+    WHERE mi.is_available = true
+      AND v.is_active = true
+      AND (
+        p_area_id IS NULL
+        OR EXISTS (
+          SELECT 1 FROM vendor_areas va
+          WHERE va.vendor_id = v.id AND va.area_id = p_area_id
+        )
+      )
+  ),
+  normed AS (
+    SELECT
+      r.id, r.embedding, r.is_open,
+      (r.raw_user_sim - AVG(r.raw_user_sim) OVER ())
+        / NULLIF(STDDEV_POP(r.raw_user_sim) OVER (), 0) AS z_user,
+      (r.raw_nutr_sim - AVG(r.raw_nutr_sim) OVER ())
+        / NULLIF(STDDEV_POP(r.raw_nutr_sim) OVER (), 0) AS z_nutr,
+      (r.raw_trend - AVG(r.raw_trend) OVER ())
+        / NULLIF(STDDEV_POP(r.raw_trend) OVER (), 0) AS z_trend
+    FROM raw r
+  )
+  SELECT
+    id, embedding,
+    (COALESCE(z_user, 0) + COALESCE(z_nutr, 0) + COALESCE(z_trend, 0)
+      + CASE WHEN is_open THEN 0.5 ELSE 0 END)::numeric AS score
+  FROM normed
+  ORDER BY score DESC NULLS LAST
+  LIMIT v_pool_size;
+
+  -- MMR rerank: λ × relevance − (1 − λ) × max similarity-to-already-selected
+  LOOP
+    EXIT WHEN COALESCE(array_length(v_selected, 1), 0) >= p_limit;
+
+    SELECT c.id INTO v_pick
+    FROM _rank_cand c
+    WHERE c.id <> ALL(v_selected)
+    ORDER BY (
+      v_lambda * c.score
+      - (1 - v_lambda) * COALESCE(
+          (SELECT MAX(1.0 - (c.embedding <=> s.embedding))::numeric
+           FROM _rank_cand s
+           WHERE s.id = ANY(v_selected)
+             AND s.embedding IS NOT NULL
+             AND c.embedding IS NOT NULL),
+          0::numeric
+        )
+    ) DESC NULLS LAST, c.id
+    LIMIT 1;
+
+    EXIT WHEN v_pick IS NULL;
+    v_selected := array_append(v_selected, v_pick);
+  END LOOP;
+
+  -- Final projection — preserves original 16-column shape for the UI
+  RETURN QUERY
+  WITH ordered AS (
+    SELECT u.id, u.ord
+    FROM unnest(v_selected) WITH ORDINALITY AS u(id, ord)
+  ),
+  user_tags AS (
+    SELECT tag_slug, score FROM user_tag_preferences
+    WHERE user_id = v_user_id
+  )
+  SELECT
+    mi.id,
+    mi.name,
+    mi.description,
+    mi.price,
+    mi.image_url,
+    mi.ai_tags,
+    mi.ai_description,
+    COALESCE(
+      NULLIF(mi.tags, ARRAY[]::text[]),
+      ARRAY(
+        SELECT tv.label
+        FROM unnest(mi.ai_tags) AS t(slug)
+        JOIN tag_vocabulary tv ON tv.slug = t.slug
+        ORDER BY tv.sort_order
+      )
+    ) AS tags,
+    mi.calories,
+    mi.protein,
+    mi.sodium,
+    mi.vendor_id,
+    v.name AS vendor_name,
+    v.is_open AS vendor_is_open,
+    c.score AS match_score,
+    (
+      SELECT tv.label
+      FROM user_tags ut
+      JOIN tag_vocabulary tv ON tv.slug = ut.tag_slug
+      WHERE ut.tag_slug = ANY (mi.ai_tags)
+      ORDER BY ut.score DESC
+      LIMIT 1
+    ) AS top_tag_label
+  FROM ordered o
+  JOIN _rank_cand c ON c.id = o.id
+  JOIN menu_items mi ON mi.id = o.id
+  JOIN vendors v ON v.id = mi.vendor_id
+  ORDER BY o.ord;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION rank_menu_items_for_home(uuid, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rank_menu_items_for_home(uuid, int) TO anon, authenticated;


### PR DESCRIPTION
## Summary
- 新增 `user_embeddings` 物化表：每位 user 的口味向量 = confirm 過所有菜的 embedding 平均
- 換掉舊的 linear `tag×10 + nutrition×2 + ln(trend)×5` —— 三因子 z-score 歸一化 + MMR (λ=0.7) 多樣性 rerank
- RPC 回傳 16-column shape 不變，UI / `lib/recommendation.ts` 零改動
- 冷啟動退化路徑：無 user vector → z_user 鎖 0 → trend + nutrition + open 主導，跟舊版同效果

## Test plan
- [x] Migration apply 線上，user_embeddings backfill 8/8 confirmed users
- [x] Cold-start 路徑 RPC 跑通（auth.uid NULL → trend-driven，分數合理分佈）
- [x] 語意正確性實測：top user 點過排骨便當 56 次，他的 vector cosine 最近 5 道菜中 3 道是他點過的（排骨/控肉/雞腿便當）、2 道沒點過但同類（滷雞腿、炸蝦天婦羅定食）
- [x] CI 過

## Plan context
PR #1 of 4 in the recommendation upgrade plan. 下一波：
- #2 行為訊號層（曝光/點擊 + 時間衰減 + 負反饋）
- #3 情境向量（時段/天氣 query embedding 混入）
- #4 Bandit 驚喜餐 + LLM 推薦理由 offline cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)