### PR TITLE
feat(db): impressions logging + trend decay + skip-aware user vector

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -61,13 +61,16 @@ types/
 - `tag_vocabulary` — Controlled-vocab AI tags (42 slugs × 6 axes); `validate_ai_tags` trigger enforces `menu_items.ai_tags ⊆ tag_vocabulary.slug`
 - `user_tag_preferences` — Per-user tag affinity score, accumulated on order confirm
 - `user_nutrition_profile` — Per-user running average consumption (calories/protein/sodium/sugar)
-- `user_embeddings` — Per-user 512-dim taste vector (mean of confirmed items' embeddings); recomputed on every confirm
+- `user_embeddings` — Per-user 512-dim taste vector (mean of confirmed items' embeddings minus 0.3 × skipped items' embeddings); recomputed on every confirm + daily cron
+- `menu_item_impressions` — 1 row per user × item × date; powers the "skipped" signal (impressed ≥ 3 days ago and never confirmed)
 
 ### DB Functions
-- `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally. Three-factor z-score normalised ranking: (a) cosine sim between `user_embeddings.embedding` and `menu_items.embedding`, (b) nutrition profile similarity, (c) ln(7-day trend). Plus `+0.5` open-vendor bonus. Top `limit × 3` candidate pool then reranked by MMR (λ = 0.7) for diversity. Cold-start (no user vector) → z_user clamps to 0, trend + nutrition + open drive ranking. Returns `match_score` + explainable `top_tag_label`.
+- `rank_menu_items_for_home(p_area_id, p_limit)` — SECURITY DEFINER; reads `auth.uid()` internally. Three-factor z-score normalised ranking: (a) cosine sim between `user_embeddings.embedding` and `menu_items.embedding`, (b) nutrition profile similarity, (c) ln(time-decayed 14-day trend, τ = 3 days). Plus `+0.5` open-vendor bonus. Top `limit × 3` candidate pool then reranked by MMR (λ = 0.7) for diversity. Cold-start (no user vector) → z_user clamps to 0, trend + nutrition + open drive ranking. Returns `match_score` + explainable `top_tag_label`.
 - `hybrid_search(p_query, p_query_embedding, p_area_id, p_limit)` — RRF (k=60) of pg_trgm keyword match + pgvector cosine semantic match. `p_query_embedding` 可為 NULL 讓 OpenAI 未配置時降級為 keyword-only。
 - `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean + recomputes user embedding (full re-mean over all confirmed items).
 - `rollover_daily_slots()` — SECURITY DEFINER; scheduled via pg_cron `rollover_daily_slots` job (`0 22 * * *` UTC = 06:00 Asia/Taipei). Materialises daily_slots for next 14 days from `menu_items.default_max_qty`, filtered by `vendors.is_active` + `vendors.operating_days` + `menu_items.is_available` + `default_max_qty > 0`. `ON CONFLICT (menu_item_id, date) DO NOTHING` preserves vendor's manual max_qty tweaks.
+- `refresh_all_user_embeddings()` — SECURITY DEFINER; scheduled via pg_cron `refresh_user_embeddings` job (`0 2 * * *` UTC = 10:00 Asia/Taipei). Recomputes every user's vector as `confirmed_mean − 0.3 × skipped_mean` so skip signal (impressed ≥ 3 days ago, never confirmed) flows in without per-impression trigger thrashing.
+- `combine_user_vectors(confirmed, skipped, beta)` — IMMUTABLE helper; element-wise `confirmed − β × skipped` since pgvector lacks scalar-multiply. Called once per user per cron run.
 
 ### Edge Functions
 - `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). Also generates `embedding` (text-embedding-3-small @ 512 dims) from name + ai_description + tag labels. 60s idempotency, max 100 items/invoke.
@@ -76,9 +79,10 @@ types/
 
 ### Recommendation pipeline (offline-only LLM)
 1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` + `embedding` (+ missing nutrition).
-2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile` + `user_embeddings`.
-3. Home page calls `rank_menu_items_for_home` RPC → semantic cosine + nutrition + trend with z-score normalised weights and MMR diversity rerank; no LLM in serving path.
-4. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
+2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile` + `user_embeddings` (positive signal, immediate).
+3. Home page calls `rank_menu_items_for_home` RPC → semantic cosine + nutrition + time-decayed trend with z-score normalised weights and MMR diversity rerank; no LLM in serving path. Server component fires `after()` to log impressions (1 row per user × item × date) for the skip signal.
+4. Daily 10:00 TPE cron (`refresh_user_embeddings`) bakes skipped-but-not-confirmed items into each user's vector at β = 0.3, closing the negative-feedback loop.
+5. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
 
 ### Roles
 - `user` — Employee

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,11 @@ import { FoodWheel } from "@/components/food-wheel";
 import { HomeItemCard } from "@/components/home-item-card";
 import RecommendationSection from "@/components/recommendation-section";
 import { DEFAULT_FACTORY_AREA_NAME } from "@/lib/branding";
+import { recordImpressions } from "@/lib/impressions";
 import { getHomeItems, getTrendingItems } from "@/lib/recommendation";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { after } from "next/server";
 
 interface Props {
   searchParams: Promise<{ area?: string }>;
@@ -42,6 +44,14 @@ export default async function HomePage({ searchParams }: Props) {
     getHomeItems(area),
     getTrendingItems(8, area),
   ]);
+
+  if (user) {
+    const userId = user.id;
+    after(async () => {
+      const ids = [...items.map((i) => i.id), ...trending.map((t) => t.id)];
+      await recordImpressions(supabase, userId, ids);
+    });
+  }
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">

--- a/lib/impressions.ts
+++ b/lib/impressions.ts
@@ -1,0 +1,19 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function recordImpressions(
+  supabase: SupabaseClient,
+  userId: string,
+  itemIds: string[],
+): Promise<void> {
+  if (itemIds.length === 0) return;
+  const today = new Date().toISOString().split("T")[0];
+  const seen = new Set<string>();
+  const rows = itemIds.flatMap((id) => {
+    if (seen.has(id)) return [];
+    seen.add(id);
+    return [{ user_id: userId, menu_item_id: id, date: today }];
+  });
+  await supabase
+    .from("menu_item_impressions")
+    .upsert(rows, { onConflict: "user_id,menu_item_id,date", ignoreDuplicates: true });
+}

--- a/supabase/migrations/20260526143709_behavior_signal_layer.sql
+++ b/supabase/migrations/20260526143709_behavior_signal_layer.sql
@@ -1,0 +1,335 @@
+-- Behaviour signal layer — PR #2 of 4.
+--
+--   1. menu_item_impressions table — 1 row per user × item × date.
+--      Lets the recommender detect repeated exposure without engagement.
+--
+--   2. Trend decay — replace SUM(qty over 7d) with SUM(qty × exp(-Δt / 3d)).
+--      Fresh orders count more; week-old hits decay toward zero. Kills the
+--      Matthew effect where last week's runaway item stays pinned forever.
+--
+--   3. Skip-aware user vector — daily pg_cron rebuilds user_embeddings as
+--      Σ confirmed_emb − 0.3 × Σ skipped_emb, where "skipped" = "impressed
+--      ≥ 3 days ago and never confirmed". β = 0.3 keeps skip a weak negative
+--      so noise can't dominate the vector. Cosine ranking is scale-invariant,
+--      so no l2-normalise step needed.
+--
+-- Confirm trigger stays (instant feedback when user orders). Cron picks up
+-- skip signal asynchronously since impressions can't sanely fire triggers.
+
+-- =====================================================================
+-- 1. menu_item_impressions
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS menu_item_impressions (
+  user_id       uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  menu_item_id  uuid NOT NULL REFERENCES menu_items(id) ON DELETE CASCADE,
+  date          date NOT NULL DEFAULT CURRENT_DATE,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, menu_item_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS menu_item_impressions_user_date_idx
+  ON menu_item_impressions (user_id, date DESC);
+
+CREATE INDEX IF NOT EXISTS menu_item_impressions_item_idx
+  ON menu_item_impressions (menu_item_id);
+
+ALTER TABLE menu_item_impressions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "menu_item_impressions_read_own" ON menu_item_impressions;
+CREATE POLICY "menu_item_impressions_read_own" ON menu_item_impressions
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS "menu_item_impressions_write_own" ON menu_item_impressions;
+CREATE POLICY "menu_item_impressions_write_own" ON menu_item_impressions
+  FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+-- =====================================================================
+-- 2. Trend decay — rewrite ranking RPC with exp decay over τ = 3 days
+-- =====================================================================
+CREATE OR REPLACE FUNCTION rank_menu_items_for_home(
+  p_area_id uuid DEFAULT NULL,
+  p_limit   int  DEFAULT 60
+)
+RETURNS TABLE (
+  id              uuid,
+  name            text,
+  description     text,
+  price           numeric,
+  image_url       text,
+  ai_tags         text[],
+  ai_description  text,
+  tags            text[],
+  calories        int,
+  protein         numeric,
+  sodium          numeric,
+  vendor_id       uuid,
+  vendor_name     text,
+  vendor_is_open  boolean,
+  match_score     numeric,
+  top_tag_label   text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_user_id   uuid := (SELECT auth.uid());
+  v_user_vec  vector(512);
+  v_nutr      record;
+  v_lambda    numeric := 0.7;
+  v_pool_size int := GREATEST(p_limit * 3, 30);
+  v_selected  uuid[] := ARRAY[]::uuid[];
+  v_pick      uuid;
+BEGIN
+  SELECT ue.embedding INTO v_user_vec
+  FROM user_embeddings ue WHERE ue.user_id = v_user_id;
+
+  SELECT * INTO v_nutr
+  FROM user_nutrition_profile WHERE user_id = v_user_id;
+
+  DROP TABLE IF EXISTS _rank_cand;
+  CREATE TEMP TABLE _rank_cand ON COMMIT DROP AS
+  WITH trending AS (
+    SELECT
+      oi.menu_item_id,
+      SUM(
+        oi.qty
+        * EXP(-EXTRACT(EPOCH FROM (now() - o.created_at)) / (3.0 * 86400))
+      )::numeric AS decay_qty
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    WHERE o.status IN ('confirmed','completed')
+      AND o.created_at > now() - interval '14 days'
+    GROUP BY oi.menu_item_id
+  ),
+  raw AS (
+    SELECT
+      mi.id,
+      mi.embedding,
+      v.is_open,
+      CASE
+        WHEN v_user_vec IS NOT NULL AND mi.embedding IS NOT NULL
+        THEN (1.0 - (mi.embedding <=> v_user_vec))::numeric
+        ELSE 0::numeric
+      END AS raw_user_sim,
+      CASE
+        WHEN v_nutr.sample_count IS NOT NULL THEN
+          1.0 / (
+            1.0
+            + COALESCE(ABS(mi.calories - v_nutr.avg_calories) / 100.0, 0)
+            + COALESCE(ABS(mi.protein  - v_nutr.avg_protein)  / 10.0,  0)
+            + COALESCE(ABS(mi.sodium   - v_nutr.avg_sodium)   / 200.0, 0)
+          )
+        ELSE 0::numeric
+      END AS raw_nutr_sim,
+      LN(1 + COALESCE(t.decay_qty, 0))::numeric AS raw_trend
+    FROM menu_items mi
+    JOIN vendors v ON v.id = mi.vendor_id
+    LEFT JOIN trending t ON t.menu_item_id = mi.id
+    WHERE mi.is_available = true
+      AND v.is_active = true
+      AND (
+        p_area_id IS NULL
+        OR EXISTS (
+          SELECT 1 FROM vendor_areas va
+          WHERE va.vendor_id = v.id AND va.area_id = p_area_id
+        )
+      )
+  ),
+  normed AS (
+    SELECT
+      r.id, r.embedding, r.is_open,
+      (r.raw_user_sim - AVG(r.raw_user_sim) OVER ())
+        / NULLIF(STDDEV_POP(r.raw_user_sim) OVER (), 0) AS z_user,
+      (r.raw_nutr_sim - AVG(r.raw_nutr_sim) OVER ())
+        / NULLIF(STDDEV_POP(r.raw_nutr_sim) OVER (), 0) AS z_nutr,
+      (r.raw_trend - AVG(r.raw_trend) OVER ())
+        / NULLIF(STDDEV_POP(r.raw_trend) OVER (), 0) AS z_trend
+    FROM raw r
+  )
+  SELECT
+    id, embedding,
+    (COALESCE(z_user, 0) + COALESCE(z_nutr, 0) + COALESCE(z_trend, 0)
+      + CASE WHEN is_open THEN 0.5 ELSE 0 END)::numeric AS score
+  FROM normed
+  ORDER BY score DESC NULLS LAST
+  LIMIT v_pool_size;
+
+  LOOP
+    EXIT WHEN COALESCE(array_length(v_selected, 1), 0) >= p_limit;
+
+    SELECT c.id INTO v_pick
+    FROM _rank_cand c
+    WHERE c.id <> ALL(v_selected)
+    ORDER BY (
+      v_lambda * c.score
+      - (1 - v_lambda) * COALESCE(
+          (SELECT MAX(1.0 - (c.embedding <=> s.embedding))::numeric
+           FROM _rank_cand s
+           WHERE s.id = ANY(v_selected)
+             AND s.embedding IS NOT NULL
+             AND c.embedding IS NOT NULL),
+          0::numeric
+        )
+    ) DESC NULLS LAST, c.id
+    LIMIT 1;
+
+    EXIT WHEN v_pick IS NULL;
+    v_selected := array_append(v_selected, v_pick);
+  END LOOP;
+
+  RETURN QUERY
+  WITH ordered AS (
+    SELECT u.id, u.ord
+    FROM unnest(v_selected) WITH ORDINALITY AS u(id, ord)
+  ),
+  user_tags AS (
+    SELECT tag_slug, score FROM user_tag_preferences
+    WHERE user_id = v_user_id
+  )
+  SELECT
+    mi.id,
+    mi.name,
+    mi.description,
+    mi.price,
+    mi.image_url,
+    mi.ai_tags,
+    mi.ai_description,
+    COALESCE(
+      NULLIF(mi.tags, ARRAY[]::text[]),
+      ARRAY(
+        SELECT tv.label
+        FROM unnest(mi.ai_tags) AS t(slug)
+        JOIN tag_vocabulary tv ON tv.slug = t.slug
+        ORDER BY tv.sort_order
+      )
+    ) AS tags,
+    mi.calories,
+    mi.protein,
+    mi.sodium,
+    mi.vendor_id,
+    v.name AS vendor_name,
+    v.is_open AS vendor_is_open,
+    c.score AS match_score,
+    (
+      SELECT tv.label
+      FROM user_tags ut
+      JOIN tag_vocabulary tv ON tv.slug = ut.tag_slug
+      WHERE ut.tag_slug = ANY (mi.ai_tags)
+      ORDER BY ut.score DESC
+      LIMIT 1
+    ) AS top_tag_label
+  FROM ordered o
+  JOIN _rank_cand c ON c.id = o.id
+  JOIN menu_items mi ON mi.id = o.id
+  JOIN vendors v ON v.id = mi.vendor_id
+  ORDER BY o.ord;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION rank_menu_items_for_home(uuid, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rank_menu_items_for_home(uuid, int) TO anon, authenticated;
+
+-- =====================================================================
+-- 3. Helper: combine confirmed and skipped vectors with β skip-weight.
+--    pgvector has no native scalar-multiplication operator, so we unpack
+--    the vectors element-wise. Called once per user per cron run — the
+--    O(dim) work is fine at MVP scale.
+-- =====================================================================
+CREATE OR REPLACE FUNCTION combine_user_vectors(
+  confirmed vector,
+  skipped   vector,
+  beta      numeric
+)
+RETURNS vector
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN skipped IS NULL THEN confirmed
+    ELSE (
+      SELECT array_agg(uc.c - beta * us.s ORDER BY uc.ord)::vector
+      FROM unnest(confirmed::real[]) WITH ORDINALITY AS uc(c, ord)
+      JOIN unnest(skipped::real[])   WITH ORDINALITY AS us(s, ord_s) ON uc.ord = us.ord_s
+    )
+  END
+$$;
+
+-- =====================================================================
+-- 4. Skip-aware user embedding refresh — daily pg_cron job
+-- =====================================================================
+CREATE OR REPLACE FUNCTION refresh_all_user_embeddings()
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  WITH confirmed AS (
+    SELECT
+      o.user_id,
+      AVG(mi.embedding)::vector(512) AS vec,
+      COUNT(*)::int AS n
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    JOIN menu_items mi ON mi.id = oi.menu_item_id
+    WHERE o.status IN ('confirmed','completed')
+      AND mi.embedding IS NOT NULL
+    GROUP BY o.user_id
+  ),
+  skipped AS (
+    SELECT
+      imp.user_id,
+      AVG(mi.embedding)::vector(512) AS vec
+    FROM menu_item_impressions imp
+    JOIN menu_items mi ON mi.id = imp.menu_item_id
+    WHERE imp.date < CURRENT_DATE - INTERVAL '3 days'
+      AND mi.embedding IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM order_items oi2
+        JOIN orders o2 ON o2.id = oi2.order_id
+        WHERE o2.user_id = imp.user_id
+          AND oi2.menu_item_id = imp.menu_item_id
+          AND o2.status IN ('confirmed','completed')
+      )
+    GROUP BY imp.user_id
+  ),
+  blended AS (
+    SELECT
+      c.user_id,
+      combine_user_vectors(c.vec, s.vec, 0.3) AS vec,
+      c.n AS n_orders
+    FROM confirmed c
+    LEFT JOIN skipped s ON s.user_id = c.user_id
+  )
+  INSERT INTO user_embeddings (user_id, embedding, n_orders, updated_at)
+  SELECT user_id, vec::vector(512), n_orders, now() FROM blended
+  WHERE vec IS NOT NULL
+  ON CONFLICT (user_id) DO UPDATE
+    SET embedding = EXCLUDED.embedding,
+        n_orders = EXCLUDED.n_orders,
+        updated_at = now();
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION refresh_all_user_embeddings() FROM PUBLIC;
+
+-- Schedule daily 02:00 UTC (10:00 Asia/Taipei) — late enough that
+-- yesterday's impression rows have settled, early enough that
+-- morning recommendations see updated vectors.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh_user_embeddings') THEN
+    PERFORM cron.schedule(
+      'refresh_user_embeddings',
+      '0 2 * * *',
+      $job$SELECT public.refresh_all_user_embeddings();$job$
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- 新表 `menu_item_impressions(user_id, menu_item_id, date)` + RLS read/write own；home server component 用 Next 16 `after()` fire-and-forget 寫入
- Trend factor 從「過去 7 天 SUM(qty)」換成 `SUM(qty × exp(-Δt / 3d))` 時間衰減，殺 Matthew effect
- 新 cron `refresh_user_embeddings`（10:00 TPE 每日）把 skip 訊號回灌 user vector：β = 0.3，skip 定義 = 「曝光 ≥ 3 天 + 從未 confirmed」
- 新 helper `combine_user_vectors(c, s, β)`：pgvector 沒 scalar-multiply，element-wise unpack 處理

## Test plan
- [x] Migration apply 線上，2 個 RLS policy + cron job 都就位
- [x] `refresh_all_user_embeddings()` 跑通，9 個 user vectors refresh
- [x] `combine_user_vectors` 回傳 512 dims 正確
- [x] Trend decay 後分數分佈更分散（6.68 / 5.02 / 3.20 / 3.20 / 2.10）取代 PR #1 結束時的「1 winner + 6 tied at 0.354」
- [x] Local build pass
- [x] CI 過

## Plan context
PR #2 of 4 in the recommendation upgrade plan. 下一波：
- #3 情境向量（時段/天氣 query embedding 混入）
- #4 Bandit 驚喜餐 + LLM 推薦理由 offline cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)