### PR TITLE
feat(db): daily surprise pick via Thompson Sampling bandit

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -64,6 +64,7 @@ types/
 - `user_embeddings` — Per-user 512-dim taste vector (mean of confirmed items' embeddings minus 0.3 × skipped items' embeddings); recomputed on every confirm + daily cron
 - `menu_item_impressions` — 1 row per user × item × date; powers the "skipped" signal (impressed ≥ 3 days ago and never confirmed)
 - `context_embeddings` — Cached embeddings keyed by `{hour_band}_{temp_band}_{rain}` so the same time-of-day × weather bucket doesn't pay OpenAI twice
+- `daily_picks` — One Thompson-Sampling surprise pick per user per day (PK: user_id + date); stores chosen menu_item_id + θ + β for traceability
 
 ### DB Functions
 - `rank_menu_items_for_home(p_area_id, p_limit, p_context_vec)` — SECURITY DEFINER; reads `auth.uid()` internally. raw_user_sim = `0.7 × cos(user_vec) + 0.3 × cos(context_vec)` when both present; either NULL → falls back to the other; both NULL → 0. Three-factor z-score normalised blend with nutrition profile similarity and ln(time-decayed 14-day trend, τ = 3 days). Plus `+0.5` open-vendor bonus. Top `limit × 3` candidate pool then reranked by MMR (λ = 0.7) for diversity. Cold-start (no user vector, no context) degrades to trend + nutrition + open. Returns `match_score` + explainable `top_tag_label`.
@@ -71,6 +72,7 @@ types/
 - `update_user_preferences_on_confirm()` — AFTER UPDATE trigger on orders; fires on `pending → confirmed`; accumulates tag scores + updates nutrition running mean + recomputes user embedding (full re-mean over all confirmed items).
 - `rollover_daily_slots()` — SECURITY DEFINER; scheduled via pg_cron `rollover_daily_slots` job (`0 22 * * *` UTC = 06:00 Asia/Taipei). Materialises daily_slots for next 14 days from `menu_items.default_max_qty`, filtered by `vendors.is_active` + `vendors.operating_days` + `menu_items.is_available` + `default_max_qty > 0`. `ON CONFLICT (menu_item_id, date) DO NOTHING` preserves vendor's manual max_qty tweaks.
 - `refresh_all_user_embeddings()` — SECURITY DEFINER; scheduled via pg_cron `refresh_user_embeddings` job (`0 2 * * *` UTC = 10:00 Asia/Taipei). Recomputes every user's vector as `confirmed_mean − 0.3 × skipped_mean` so skip signal (impressed ≥ 3 days ago, never confirmed) flows in without per-impression trigger thrashing.
+- `compute_daily_picks()` — SECURITY DEFINER; scheduled via pg_cron `compute_daily_picks` job (same window as user-vector refresh). For each user with history, samples one item from the top-30 candidate pool via Beta(1, impressions+1) — closed-form `θ = 1 − (1 − U)^(1/β)`. Already-confirmed items are excluded. Cold-start user (no `user_embeddings` row) → candidates ranked purely by ln(decay_trend), β=1 → uniform random pick.
 - `combine_user_vectors(confirmed, skipped, beta)` — IMMUTABLE helper; element-wise `confirmed − β × skipped` since pgvector lacks scalar-multiply. Called once per user per cron run.
 
 ### Edge Functions
@@ -82,7 +84,7 @@ types/
 1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` + `embedding` (+ missing nutrition).
 2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile` + `user_embeddings` (positive signal, immediate).
 3. Home server component fetches Open-Meteo current conditions (Next 16 fetch cache 30 min) → maps `{hour_band, temp_band, rain}` to a fixed English phrase → looks up `context_embeddings`; on miss invokes `embed-query` edge function and upserts. The resulting context vector is passed to `rank_menu_items_for_home(area, limit, context_vec)` → semantic cosine + nutrition + time-decayed trend with z-score normalised weights and MMR diversity rerank; no LLM in serving path. Server component also fires `after()` to log impressions (1 row per user × item × date) for the skip signal.
-4. Daily 10:00 TPE cron (`refresh_user_embeddings`) bakes skipped-but-not-confirmed items into each user's vector at β = 0.3, closing the negative-feedback loop.
+4. Daily 10:00 TPE cron (`refresh_user_embeddings`) bakes skipped-but-not-confirmed items into each user's vector at β = 0.3, closing the negative-feedback loop. Same window, `compute_daily_picks` Thompson-samples one surprise pick per user from a personalised top-30 pool and writes to `daily_picks`; the homepage renders it as a "🎁 今日驚喜" card above the trending carousel.
 5. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
 
 ### Roles

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { HomeItemCard } from "@/components/home-item-card";
 import RecommendationSection from "@/components/recommendation-section";
 import { DEFAULT_FACTORY_AREA_NAME } from "@/lib/branding";
 import { getContextEmbedding, getCurrentContext } from "@/lib/context";
+import { getDailyPick } from "@/lib/daily-pick";
 import { recordImpressions } from "@/lib/impressions";
 import { getHomeItems, getTrendingItems } from "@/lib/recommendation";
 import { createClient } from "@/lib/supabase/server";
@@ -44,9 +45,10 @@ export default async function HomePage({ searchParams }: Props) {
   const ctx = await getCurrentContext();
   const contextVec = ctx ? await getContextEmbedding(supabase, ctx) : null;
 
-  const [items, trending] = await Promise.all([
+  const [items, trending, dailyPick] = await Promise.all([
     getHomeItems(area, 60, contextVec),
     getTrendingItems(8, area),
+    user ? getDailyPick(supabase, user.id) : Promise.resolve(null),
   ]);
 
   if (user) {
@@ -60,6 +62,15 @@ export default async function HomePage({ searchParams }: Props) {
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
       <div className="w-full p-4 flex flex-col gap-8">
+        {dailyPick && (
+          <section className="flex flex-col gap-3">
+            <h2 className="text-heading font-semibold">🎁 今日驚喜</h2>
+            <div className="max-w-sm">
+              <HomeItemCard item={dailyPick} />
+            </div>
+          </section>
+        )}
+
         {trending.length > 0 && (
           <RecommendationSection title="🔥 熱銷排行" items={trending} accent />
         )}

--- a/lib/daily-pick.ts
+++ b/lib/daily-pick.ts
@@ -1,0 +1,49 @@
+import type { HomeItem } from "@/lib/recommendation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function getDailyPick(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<HomeItem | null> {
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data: pick } = await supabase
+    .from("daily_picks")
+    .select("menu_item_id")
+    .eq("user_id", userId)
+    .eq("date", today)
+    .maybeSingle();
+
+  if (!pick?.menu_item_id) return null;
+
+  const { data: item } = await supabase
+    .from("menu_items")
+    .select(
+      "id, name, description, price, image_url, ai_tags, ai_description, tags, calories, protein, sodium, vendor_id, is_available, vendors!inner(name, is_open, is_active)",
+    )
+    .eq("id", pick.menu_item_id)
+    .maybeSingle();
+
+  if (!item || !item.is_available) return null;
+  const vendor = item.vendors as unknown as { name: string; is_open: boolean; is_active: boolean };
+  if (!vendor.is_active) return null;
+
+  return {
+    id: item.id,
+    name: item.name,
+    description: item.description,
+    price: item.price,
+    image_url: item.image_url,
+    tags: item.tags ?? [],
+    ai_tags: item.ai_tags ?? [],
+    ai_description: item.ai_description,
+    calories: item.calories,
+    protein: item.protein,
+    sodium: item.sodium,
+    vendor_id: item.vendor_id,
+    vendor_name: vendor.name,
+    vendor_is_open: vendor.is_open,
+    match_score: 0,
+    top_tag_label: null,
+  };
+}

--- a/supabase/migrations/20260526145135_daily_surprise_pick.sql
+++ b/supabase/migrations/20260526145135_daily_surprise_pick.sql
@@ -1,0 +1,147 @@
+-- Daily surprise pick — PR #4 of 4 (Bandit half).
+--
+-- One "今日驚喜" recommendation per user per day, picked via Thompson Sampling
+-- on Beta(α=1, β=impressions+1). Mean shrinks as the user sees the item more,
+-- so the bandit naturally pushes never-seen / low-exposure items forward
+-- while staying within a quality candidate pool.
+--
+--   • Candidate pool (per user): top 30 items by
+--       cos(user_vec, item_vec) + 0.5 × ln(1 + decay_trend),
+--     excluding anything the user has already confirmed.
+--   • Beta(1, β) closed-form sample: θ = 1 − (1 − U)^(1/β),
+--     where U ~ uniform(0,1) and β = impressions_count + 1.
+--   • Daily cron at 02:00 UTC (10:00 TPE), same window as the user-vector
+--     refresh.
+
+CREATE TABLE IF NOT EXISTS daily_picks (
+  user_id      uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  date         date NOT NULL DEFAULT CURRENT_DATE,
+  menu_item_id uuid NOT NULL REFERENCES menu_items(id) ON DELETE CASCADE,
+  theta        numeric NOT NULL,
+  beta         numeric NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS daily_picks_user_idx ON daily_picks (user_id, date DESC);
+
+ALTER TABLE daily_picks ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "daily_picks_read_own" ON daily_picks;
+CREATE POLICY "daily_picks_read_own" ON daily_picks
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+CREATE OR REPLACE FUNCTION compute_daily_picks()
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  WITH user_pool AS (
+    SELECT DISTINCT user_id FROM (
+      SELECT user_id FROM orders WHERE status IN ('confirmed','completed')
+      UNION
+      SELECT user_id FROM menu_item_impressions WHERE date > CURRENT_DATE - INTERVAL '14 days'
+    ) u
+  ),
+  trending AS (
+    SELECT oi.menu_item_id,
+      SUM(oi.qty * EXP(-EXTRACT(EPOCH FROM (now() - o.created_at)) / (3.0 * 86400)))::numeric AS decay_qty
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    WHERE o.status IN ('confirmed','completed')
+      AND o.created_at > now() - interval '14 days'
+    GROUP BY oi.menu_item_id
+  ),
+  user_imp AS (
+    SELECT user_id, menu_item_id, COUNT(*)::int AS imp_count
+    FROM menu_item_impressions
+    WHERE date > CURRENT_DATE - INTERVAL '14 days'
+    GROUP BY user_id, menu_item_id
+  ),
+  user_confirmed AS (
+    SELECT DISTINCT o.user_id, oi.menu_item_id
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    WHERE o.status IN ('confirmed','completed')
+  ),
+  active_items AS (
+    SELECT mi.id, mi.embedding
+    FROM menu_items mi
+    JOIN vendors v ON v.id = mi.vendor_id
+    WHERE mi.is_available = true
+      AND v.is_active = true
+      AND mi.embedding IS NOT NULL
+  ),
+  candidates AS (
+    SELECT
+      up.user_id,
+      ai.id AS menu_item_id,
+      COALESCE(1.0 - (ai.embedding <=> ue.embedding), 0)::numeric
+        + 0.5 * LN(1 + COALESCE(t.decay_qty, 0))::numeric AS rank_score,
+      COALESCE(ui.imp_count, 0) AS imp_count
+    FROM user_pool up
+    CROSS JOIN active_items ai
+    LEFT JOIN user_embeddings ue ON ue.user_id = up.user_id
+    LEFT JOIN trending t ON t.menu_item_id = ai.id
+    LEFT JOIN user_imp ui ON ui.user_id = up.user_id AND ui.menu_item_id = ai.id
+    WHERE NOT EXISTS (
+      SELECT 1 FROM user_confirmed uc
+      WHERE uc.user_id = up.user_id AND uc.menu_item_id = ai.id
+    )
+  ),
+  ranked AS (
+    SELECT *,
+      ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY rank_score DESC) AS r
+    FROM candidates
+  ),
+  top_pool AS (
+    SELECT user_id, menu_item_id, imp_count
+    FROM ranked WHERE r <= 30
+  ),
+  sampled AS (
+    SELECT
+      user_id, menu_item_id,
+      (imp_count + 1)::numeric AS beta,
+      (1 - power(1 - random(), 1.0 / (imp_count + 1)))::numeric AS theta
+    FROM top_pool
+  ),
+  picked AS (
+    SELECT DISTINCT ON (user_id)
+      user_id, menu_item_id, theta, beta
+    FROM sampled
+    ORDER BY user_id, theta DESC
+  ),
+  ins AS (
+    INSERT INTO daily_picks (user_id, date, menu_item_id, theta, beta)
+    SELECT user_id, CURRENT_DATE, menu_item_id, theta, beta FROM picked
+    ON CONFLICT (user_id, date) DO UPDATE
+      SET menu_item_id = EXCLUDED.menu_item_id,
+          theta = EXCLUDED.theta,
+          beta = EXCLUDED.beta
+    RETURNING 1
+  )
+  SELECT COUNT(*)::int INTO v_count FROM ins;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION compute_daily_picks() FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'compute_daily_picks') THEN
+    PERFORM cron.schedule(
+      'compute_daily_picks',
+      '0 2 * * *',
+      $job$SELECT public.compute_daily_picks();$job$
+    );
+  END IF;
+END $$;
+
+-- Immediate backfill so the surprise card appears the moment this migration applies.
+SELECT public.compute_daily_picks();


### PR DESCRIPTION
## Summary
- 新表 `daily_picks(user_id, date) PK + menu_item_id + θ + β`，每位 user 每天一道「🎁 今日驚喜」
- `compute_daily_picks()` SQL function：候選池 = `cos(user_vec, item_vec) + 0.5 × ln(1 + decay_trend)` 的 top 30，扣掉已 confirmed 過的菜
- Beta(α=1, β=impressions+1) 抽樣，closed-form `θ = 1 − (1 − U)^(1/β)` — 一條 CTE chain 解掉，不需外掛 sampling library
- Cron 排 02:00 UTC（10:00 TPE），跟 `refresh_user_embeddings` 同班；migration 末尾 immediate backfill
- 首頁 server component fetch + 顯示「🎁 今日驚喜」卡片在 trending carousel 上方

## Test plan
- [x] Migration apply 線上，9 個 user 全拿到 daily pick，每人不同（叉燒飯 / 豆腐漢堡排 / 薯條 / 滷雞腿 / 麻辣鍋 / etc）
- [x] β 分佈合理：大部分 1.00（impressions 表還在 warm-up），1 個 2.00（已曝光 1 次仍被選）
- [x] Cron job `compute_daily_picks` 排上
- [x] RLS `daily_picks_read_own` 就位
- [x] Local build pass
- [x] CI 過

## Plan context
PR #4 of 4. 剩 PR #5（LLM 推薦理由 offline cache），是體驗加分項，問你要不要繼續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)