### PR TITLE
feat(db): LLM personalised reason cache for homepage cards

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -65,6 +65,7 @@ types/
 - `menu_item_impressions` — 1 row per user × item × date; powers the "skipped" signal (impressed ≥ 3 days ago and never confirmed)
 - `context_embeddings` — Cached embeddings keyed by `{hour_band}_{temp_band}_{rain}` so the same time-of-day × weather bucket doesn't pay OpenAI twice
 - `daily_picks` — One Thompson-Sampling surprise pick per user per day (PK: user_id + date); stores chosen menu_item_id + θ + β for traceability
+- `personalized_reasons` — Per (user, menu_item) cached LLM recommendation sentence; 24h TTL, lazy-filled on homepage render via the `generate-reasons` edge function
 
 ### DB Functions
 - `rank_menu_items_for_home(p_area_id, p_limit, p_context_vec)` — SECURITY DEFINER; reads `auth.uid()` internally. raw_user_sim = `0.7 × cos(user_vec) + 0.3 × cos(context_vec)` when both present; either NULL → falls back to the other; both NULL → 0. Three-factor z-score normalised blend with nutrition profile similarity and ln(time-decayed 14-day trend, τ = 3 days). Plus `+0.5` open-vendor bonus. Top `limit × 3` candidate pool then reranked by MMR (λ = 0.7) for diversity. Cold-start (no user vector, no context) degrades to trend + nutrition + open. Returns `match_score` + explainable `top_tag_label`.
@@ -79,13 +80,15 @@ types/
 - `generate-menu-item-tags` — Invoked by Server Actions / backfill script. Calls OpenAI with structured outputs enum-constrained to `tag_vocabulary.slug`. Co-fills missing nutrition fields (`NULL`-only, never overrides vendor input). Also generates `embedding` (text-embedding-3-small @ 512 dims) from name + ai_description + tag labels. 60s idempotency, max 100 items/invoke.
 - `embed-query` — Search-time helper: embeds query string → returns 512-dim vector for `hybrid_search` RPC.
 - `rerank-search` — Search-time reranker: takes `hybrid_search` candidates + 原始 query，用 `gpt-5.4-mini` structured outputs 依「意圖契合度」(含「輕一點」→ 低熱量/低鈉偏好) 給每個候選 0~1 分。Online LLM call，與 `embed-query` 同 posture；caller (`lib/search.ts`) 視失敗為 best-effort 並降級回 RRF 順序。
+- `generate-reasons` — Homepage reason generator: takes the items currently shown to the caller + reads their `user_tag_preferences`, calls `gpt-5.4-mini` once per cache-missing item (concurrency 5), upserts into `personalized_reasons` with a 24h TTL. Invoked fire-and-forget via `after()` from `app/page.tsx`; failures degrade silently to no-reason cards (fall back to `ai_description`).
 
 ### Recommendation pipeline (offline-only LLM)
 1. Vendor inserts menu item → Next 16 `after()` fires `generate-menu-item-tags` edge function → writes `ai_tags` + `ai_description` + `embedding` (+ missing nutrition).
 2. User confirms order → `update_preferences_on_order_confirm` trigger updates `user_tag_preferences` + `user_nutrition_profile` + `user_embeddings` (positive signal, immediate).
 3. Home server component fetches Open-Meteo current conditions (Next 16 fetch cache 30 min) → maps `{hour_band, temp_band, rain}` to a fixed English phrase → looks up `context_embeddings`; on miss invokes `embed-query` edge function and upserts. The resulting context vector is passed to `rank_menu_items_for_home(area, limit, context_vec)` → semantic cosine + nutrition + time-decayed trend with z-score normalised weights and MMR diversity rerank; no LLM in serving path. Server component also fires `after()` to log impressions (1 row per user × item × date) for the skip signal.
 4. Daily 10:00 TPE cron (`refresh_user_embeddings`) bakes skipped-but-not-confirmed items into each user's vector at β = 0.3, closing the negative-feedback loop. Same window, `compute_daily_picks` Thompson-samples one surprise pick per user from a personalised top-30 pool and writes to `daily_picks`; the homepage renders it as a "🎁 今日驚喜" card above the trending carousel.
-5. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
+5. After rendering, homepage's `after()` hook checks `personalized_reasons` cache; items missing or > 24h stale trigger the `generate-reasons` edge function to fill the cache. Next render picks up reasons and renders them in italic text on each card; failures are silent (cards fall back to `ai_description`).
+6. Search (`/search?q=...`) → `embed-query` edge function (one OpenAI call) → `hybrid_search` RPC (trgm + pgvector RRF) 過度檢索候選池 (40) → `rerank-search` edge function (LLM rerank by 自然語言意圖) → 取前 `limit`。「今天好熱」走 semantic 路徑找到冰品/飲品；「牛肉麵」走 keyword 路徑命中所有牛肉麵變體；「我今天想吃輕一點的」靠 rerank 依熱量/鈉把清爽餐點往前排。rerank 為 best-effort，失敗時降級回 RRF 順序。
 
 ### Roles
 - `user` — Employee

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { getContextEmbedding, getCurrentContext } from "@/lib/context";
 import { getDailyPick } from "@/lib/daily-pick";
 import { recordImpressions } from "@/lib/impressions";
 import { getHomeItems, getTrendingItems } from "@/lib/recommendation";
+import { attachReasons, fetchReasonsForItems, triggerReasonGeneration } from "@/lib/reasons";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { after } from "next/server";
@@ -51,11 +52,25 @@ export default async function HomePage({ searchParams }: Props) {
     user ? getDailyPick(supabase, user.id) : Promise.resolve(null),
   ]);
 
+  let itemsWithReasons = items as ReturnType<typeof attachReasons<typeof items[number]>>;
   if (user) {
     const userId = user.id;
+    const topForReasons = items.slice(0, 12);
+    const reasons = await fetchReasonsForItems(
+      supabase,
+      userId,
+      topForReasons.map((i) => i.id),
+    );
+    itemsWithReasons = attachReasons(items, reasons);
+
     after(async () => {
       const ids = [...items.map((i) => i.id), ...trending.map((t) => t.id)];
       await recordImpressions(supabase, userId, ids);
+
+      const missing = topForReasons.filter((i) => !reasons.has(i.id));
+      if (missing.length > 0) {
+        await triggerReasonGeneration(supabase, missing);
+      }
     });
   }
 
@@ -87,7 +102,7 @@ export default async function HomePage({ searchParams }: Props) {
               <section className="flex flex-col gap-3">
                 <h2 className="text-heading font-semibold">所有餐點</h2>
                 <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                  {items.map((item) => (
+                  {itemsWithReasons.map((item) => (
                     <HomeItemCard key={item.id} item={item} />
                   ))}
                 </div>

--- a/components/home-item-card.tsx
+++ b/components/home-item-card.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 interface Props {
-  item: HomeItem;
+  item: HomeItem & { reason?: string | null };
 }
 
 export function HomeItemCard({ item }: Props) {
@@ -43,9 +43,11 @@ export function HomeItemCard({ item }: Props) {
           <p className="text-heading-sm font-semibold shrink-0">${item.price}</p>
         </div>
         <p className="text-body text-muted-foreground truncate">{item.vendor_name}</p>
-        {item.ai_description && (
+        {item.reason ? (
+          <p className="text-body text-foreground italic line-clamp-2">{item.reason}</p>
+        ) : item.ai_description ? (
           <p className="text-body text-muted-foreground line-clamp-2">{item.ai_description}</p>
-        )}
+        ) : null}
         {(item.calories || item.protein) && (
           <div className="flex flex-wrap gap-x-2 text-meta text-muted-foreground">
             {item.calories && <span>{item.calories} kcal</span>}

--- a/lib/reasons.ts
+++ b/lib/reasons.ts
@@ -1,0 +1,55 @@
+import type { HomeItem } from "@/lib/recommendation";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+export async function fetchReasonsForItems(
+  supabase: SupabaseClient,
+  userId: string,
+  itemIds: string[],
+): Promise<Map<string, string>> {
+  if (itemIds.length === 0) return new Map();
+  const { data } = await supabase
+    .from("personalized_reasons")
+    .select("menu_item_id, reason, generated_at")
+    .eq("user_id", userId)
+    .in("menu_item_id", itemIds);
+  const map = new Map<string, string>();
+  const cutoff = Date.now() - TTL_MS;
+  for (const row of data ?? []) {
+    if (new Date(row.generated_at).getTime() >= cutoff) {
+      map.set(row.menu_item_id, row.reason);
+    }
+  }
+  return map;
+}
+
+export type ItemWithReason = HomeItem & { reason: string | null };
+
+export function attachReasons<T extends HomeItem>(
+  items: T[],
+  reasons: Map<string, string>,
+): (T & { reason: string | null })[] {
+  return items.map((it) => ({ ...it, reason: reasons.get(it.id) ?? null }));
+}
+
+export async function triggerReasonGeneration(
+  supabase: SupabaseClient,
+  items: HomeItem[],
+): Promise<void> {
+  if (items.length === 0) return;
+  try {
+    await supabase.functions.invoke("generate-reasons", {
+      body: {
+        items: items.slice(0, 20).map((it) => ({
+          id: it.id,
+          name: it.name,
+          ai_description: it.ai_description,
+          ai_tags: it.ai_tags,
+        })),
+      },
+    });
+  } catch (e) {
+    console.error("generate-reasons trigger failed:", e);
+  }
+}

--- a/supabase/functions/generate-reasons/deno.json
+++ b/supabase/functions/generate-reasons/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "openai": "npm:openai@4"
+  }
+}

--- a/supabase/functions/generate-reasons/index.ts
+++ b/supabase/functions/generate-reasons/index.ts
@@ -1,0 +1,184 @@
+// generate-reasons
+//
+// Generates short, personalised recommendation sentences for the homepage.
+// Caller passes the items currently shown to the user; for each item missing
+// (or with a stale, > 24h cache row), call OpenAI once with the user's top
+// tag preferences and the item's metadata. Upsert the result.
+//
+// Online LLM call, but fire-and-forget from the homepage's after() hook —
+// failures degrade silently to no-reason cards.
+//
+// Required secret: OPENAI_API_KEY
+// Optional: OPENAI_REASON_MODEL (default OPENAI_MODEL, default "gpt-5.4-mini")
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import OpenAI from "npm:openai@4";
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")!;
+const OPENAI_MODEL =
+  Deno.env.get("OPENAI_REASON_MODEL") ?? Deno.env.get("OPENAI_MODEL") ?? "gpt-5.4-mini";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+const MAX_ITEMS = 20;
+const TTL_HOURS = 24;
+const CONCURRENT = 5;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+interface ItemIn {
+  id: string;
+  name: string;
+  ai_description?: string | null;
+  ai_tags?: string[];
+}
+
+interface OutRow {
+  id: string;
+  reason: string;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: CORS_HEADERS });
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  const auth = req.headers.get("Authorization") ?? "";
+  if (!auth.startsWith("Bearer ")) return json({ error: "missing auth" }, 401);
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return json({ error: "unauthenticated" }, 401);
+
+  let payload: { items?: unknown };
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: "invalid json" }, 400);
+  }
+  if (!Array.isArray(payload.items)) return json({ error: "items required" }, 400);
+
+  const items = (payload.items as ItemIn[])
+    .filter((it) => it && typeof it.id === "string" && typeof it.name === "string")
+    .slice(0, MAX_ITEMS);
+  if (items.length === 0) return json({ generated: 0 });
+
+  // Find which items already have a fresh cache row.
+  const ids = items.map((i) => i.id);
+  const { data: existing } = await supabase
+    .from("personalized_reasons")
+    .select("menu_item_id, generated_at")
+    .eq("user_id", user.id)
+    .in("menu_item_id", ids);
+  const freshCutoff = Date.now() - TTL_HOURS * 60 * 60 * 1000;
+  const freshIds = new Set(
+    (existing ?? [])
+      .filter((r) => new Date(r.generated_at).getTime() >= freshCutoff)
+      .map((r) => r.menu_item_id as string),
+  );
+  const todo = items.filter((it) => !freshIds.has(it.id));
+  if (todo.length === 0) return json({ generated: 0, cached: items.length });
+
+  // Pull this user's top tags for prompt context.
+  const { data: tagRows } = await supabase
+    .from("user_tag_preferences")
+    .select("tag_slug, score")
+    .order("score", { ascending: false })
+    .limit(6);
+  const { data: tagLabels } = await supabase
+    .from("tag_vocabulary")
+    .select("slug, label");
+  const labelMap = new Map((tagLabels ?? []).map((t) => [t.slug as string, t.label as string]));
+  const topTags = (tagRows ?? [])
+    .map((r) => labelMap.get(r.tag_slug as string) ?? (r.tag_slug as string))
+    .filter(Boolean);
+
+  const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+  const out: OutRow[] = [];
+
+  // Concurrency-limited dispatch.
+  let cursor = 0;
+  async function worker() {
+    while (cursor < todo.length) {
+      const idx = cursor++;
+      const it = todo[idx];
+      try {
+        const itemTags = (it.ai_tags ?? [])
+          .map((s) => labelMap.get(s) ?? s)
+          .filter(Boolean)
+          .slice(0, 5);
+        const completion = await openai.chat.completions.create({
+          model: OPENAI_MODEL,
+          messages: [
+            {
+              role: "system",
+              content: SYSTEM_PROMPT,
+            },
+            {
+              role: "user",
+              content: buildUserPrompt(topTags, it.name, it.ai_description ?? "", itemTags),
+            },
+          ],
+          max_tokens: 80,
+        });
+        const reason = completion.choices[0]?.message?.content?.trim();
+        if (reason) out.push({ id: it.id, reason });
+      } catch (e) {
+        console.error("generate-reason failed for item", it.id, e);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENT, todo.length) }, worker));
+
+  if (out.length > 0) {
+    const rows = out.map((o) => ({
+      user_id: user.id,
+      menu_item_id: o.id,
+      reason: o.reason,
+      generated_at: new Date().toISOString(),
+    }));
+    await supabase
+      .from("personalized_reasons")
+      .upsert(rows, { onConflict: "user_id,menu_item_id" });
+  }
+
+  return json({ generated: out.length, cached: freshIds.size, requested: items.length });
+});
+
+const SYSTEM_PROMPT = `你是訂餐 app 的推薦助手。根據用戶過去最常選的口味標籤，為每道菜寫一句 20–35 字的繁體中文推薦語。
+
+規則：
+- 用親切、自然的口氣，像朋友推坑
+- 不要重複菜名
+- 不要用 markdown、emoji、列表
+- 不要說「推薦」「建議」這種空話，要扣到具體理由（口味/食材/情境）
+- 一句話結尾`;
+
+function buildUserPrompt(
+  topTags: string[],
+  itemName: string,
+  itemDesc: string,
+  itemTags: string[],
+): string {
+  const tagsLine = topTags.length > 0 ? topTags.join("、") : "（尚無口味紀錄）";
+  return `用戶過去最愛的口味：${tagsLine}
+
+這道菜：${itemName}
+菜的標籤：${itemTags.length > 0 ? itemTags.join("、") : "（無）"}
+${itemDesc ? `簡介：${itemDesc}` : ""}
+
+寫一句個性化推薦語。`;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20260526145800_personalized_reasons.sql
+++ b/supabase/migrations/20260526145800_personalized_reasons.sql
@@ -1,0 +1,35 @@
+-- Personalised reasons cache — PR #5 of 4 (LLM half).
+--
+-- One short Traditional-Chinese sentence per (user, menu_item) explaining
+-- why we think this user will like the dish. Generated offline by the
+-- `generate-reasons` edge function (OpenAI gpt-5.4-mini) and cached for 24h
+-- to keep the homepage cheap (zero LLM cost on the serving path).
+--
+-- Lazy-fill model: the homepage's `after()` hook checks the cache and only
+-- triggers the edge function for items missing or stale. First page-load per
+-- new day pays the latency once; subsequent renders hit the cache.
+
+CREATE TABLE IF NOT EXISTS personalized_reasons (
+  user_id      uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  menu_item_id uuid NOT NULL REFERENCES menu_items(id) ON DELETE CASCADE,
+  reason       text NOT NULL,
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, menu_item_id)
+);
+
+CREATE INDEX IF NOT EXISTS personalized_reasons_user_idx
+  ON personalized_reasons (user_id, generated_at DESC);
+
+ALTER TABLE personalized_reasons ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "personalized_reasons_read_own" ON personalized_reasons;
+CREATE POLICY "personalized_reasons_read_own" ON personalized_reasons
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS "personalized_reasons_write_own" ON personalized_reasons;
+CREATE POLICY "personalized_reasons_write_own" ON personalized_reasons
+  FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS "personalized_reasons_update_own" ON personalized_reasons;
+CREATE POLICY "personalized_reasons_update_own" ON personalized_reasons
+  FOR UPDATE USING (user_id = (SELECT auth.uid()));


### PR DESCRIPTION
## Summary
- 新表 `personalized_reasons(user_id, menu_item_id) PK + reason + generated_at` + 3 個 RLS policies (read/write/update own)
- 新 edge function `generate-reasons`：吃 `{ items: [...] }`，內部 fetch user 的 `user_tag_preferences` top 6 → 對 cache miss / >24h stale 的菜 batch 跑 `gpt-5.4-mini` (concurrency 5, max 20 items/invoke) → upsert
- Homepage server component fetch cache（serving path 零 LLM cost）+ `after()` fire-and-forget 補 missing/stale
- `HomeItemCard` 顯示 reason（italic foreground），沒 reason 才 fallback `ai_description`

## Test plan
- [x] Migration apply 線上，表 + 3 RLS policy 就位
- [x] Edge function deploy 線上（ACTIVE v1）
- [x] Local build pass
- [x] CI 過
- [ ] 第一次首頁 render 後背景生成 reason，第二次 render 顯示（需要 prod / preview 觸發）

## Plan context
PR #5 of 5 — 整個推薦系統升級計畫完成。串起來：
1. PR #1 語意 user embedding + MMR
2. PR #2 impressions + decay trend + skip 負反饋
3. PR #3 情境向量（時段/天氣）
4. PR #4 Thompson Sampling 每日驚喜
5. PR #5 LLM 個性化推薦理由（本 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)