### PR TITLE
fix(orders): correct QR base URL and live-update pickup status

### DIFF
--- a/app/orders/[id]/order-realtime-refresh.tsx
+++ b/app/orders/[id]/order-realtime-refresh.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function OrderRealtimeRefresh({ orderId }: { orderId: string }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`order-${orderId}`)
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "order_items", filter: `order_id=eq.${orderId}` },
+        () => router.refresh(),
+      )
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "orders", filter: `id=eq.${orderId}` },
+        () => router.refresh(),
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [orderId, router]);
+
+  return null;
+}

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -1,9 +1,11 @@
 import { createClient } from "@/lib/supabase/server";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { CheckCircle, Circle } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { format } from "date-fns";
 import { zhTW } from "date-fns/locale";
+import { OrderRealtimeRefresh } from "./order-realtime-refresh";
 import { QRCodeSVG } from "./qr-code";
 
 const STATUS_LABELS: Record<string, string> = {
@@ -63,11 +65,14 @@ export default async function OrderDetailPage({
     0
   );
 
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+  const h = await headers();
+  const host = h.get("host") ?? "localhost:3000";
+  const proto = h.get("x-forwarded-proto") ?? (host.startsWith("localhost") ? "http" : "https");
+  const baseUrl = `${proto}://${host}`;
 
   return (
     <main className="min-h-[calc(100dvh-4rem)] flex flex-col items-center">
+      <OrderRealtimeRefresh orderId={order.id} />
       <div className="w-full p-4 flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h1 className="text-2xl font-bold">訂單 #{shortId}</h1>

--- a/supabase/migrations/20260526150421_enable_realtime_orders.sql
+++ b/supabase/migrations/20260526150421_enable_realtime_orders.sql
@@ -1,0 +1,26 @@
+-- Enable Supabase Realtime broadcast for orders + order_items so the order
+-- detail page can re-render the moment a vendor scans a pickup QR.
+--
+-- The supabase_realtime publication is created by Supabase out-of-the-box but
+-- starts empty. Adding tables here is idempotent via the DO block check.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'order_items'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.order_items;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'orders'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.orders;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- QR code 在 prod 編碼成 `http://localhost:3000/api/pickup?...` 因為 `NEXT_PUBLIC_BASE_URL` 從未設定。改從 request headers (`x-forwarded-proto` + `host`) 推 base URL — dev / prod / preview 都自動對，零 config
- 商家掃 QR 後，客戶端 `/orders/[id]` 頁面要重 load 才看到綠勾。加 `<OrderRealtimeRefresh>` client component 訂閱 supabase realtime `order_items` + `orders` UPDATE，收到就 `router.refresh()`
- `supabase_realtime` publication 之前是空的（什麼都不會 broadcast），這個 PR 把 `orders` + `order_items` 加進去

## Test plan
- [x] Migration apply，publication 兩個 table 都在
- [x] Local build pass
- [x] CI 過
- [ ] 在 prod /orders/[id] 看 QR 編碼指向 nycueats.winlab.tw（不是 localhost）
- [ ] 商家掃 QR → 客戶端頁面在 1 秒內變綠勾，不用 refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)