### PR TITLE
fix(menu): auto-open add-to-order dialog from homepage card click

### DIFF
--- a/app/menu/[id]/add-to-order-dialog.tsx
+++ b/app/menu/[id]/add-to-order-dialog.tsx
@@ -15,7 +15,7 @@ import { Field, FieldGroup } from "@/components/ui/field";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { Tables } from "@/types/supabase";
 import { format } from "date-fns";
-import React, { useState, useTransition } from "react";
+import React, { useEffect, useState, useTransition } from "react";
 
 type MenuItem = Pick<Tables<"menu_items">, "id" | "name" | "description" | "price">;
 type DailySlot = Pick<Tables<"daily_slots">, "id" | "date" | "max_qty" | "reserved_qty">;
@@ -87,6 +87,15 @@ export function AddToOrderDialog({ vendorId, item, slots, optionGroups, children
     setSelections({});
     setErrorMsg(null);
   }
+
+  useEffect(() => {
+    if (disabled) return;
+    if (typeof window === "undefined") return;
+    if (window.location.hash === `#item-${item.id}`) {
+      handleOpen();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item.id, disabled]);
 
   function handleSubmit() {
     if (!slot) return;


### PR DESCRIPTION
## Summary
從首頁點 item card 會跳到 vendor menu 對應的菜（scroll 到 anchor），但 dialog 不開。要再點一次才有。HomeItemCard 已經連 `#item-${id}` 給 scroll 用，dialog mount 時順便讀 hash 自己 auto-open。

`disabled` 的菜（本週已售完）跳過 auto-open，避免空 dialog 閃出來。

## Test plan
- [x] Local build pass
- [ ] 從 https://nycueats.winlab.tw 點任一張菜卡 → 跳到 vendor menu 後 dialog 自動展開
- [ ] 點「本週已售完」的菜不會 auto-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)