### PR TITLE
fix(food-wheel): portal FAB out of the transform-wrapped page template

### DIFF
--- a/app/menu/[id]/add-to-order-dialog.tsx
+++ b/app/menu/[id]/add-to-order-dialog.tsx
@@ -92,9 +92,10 @@ export function AddToOrderDialog({ vendorId, item, slots, optionGroups, children
     if (disabled) return;
     if (typeof window === "undefined") return;
     if (window.location.hash === `#item-${item.id}`) {
+      // One-shot auto-open driven by URL hash; not a cascading render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       handleOpen();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item.id, disabled]);
 
   function handleSubmit() {

--- a/components/food-wheel.tsx
+++ b/components/food-wheel.tsx
@@ -11,7 +11,12 @@ import {
 import type { HomeItem } from "@/lib/recommendation";
 import { pickRandomItem } from "@/lib/roulette";
 import { Dices } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+
+const subscribe = () => () => {};
+const useIsClient = () =>
+  useSyncExternalStore(subscribe, () => true, () => false);
 
 interface Props {
   items: HomeItem[];
@@ -24,6 +29,7 @@ export function FoodWheel({ items }: Props) {
   const [result, setResult] = useState<HomeItem | null>(null);
   const [preview, setPreview] = useState<HomeItem | null>(null);
   const [rolling, setRolling] = useState(false);
+  const isClient = useIsClient();
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => clearTimeout(timer.current ?? undefined), []);
@@ -62,9 +68,12 @@ export function FoodWheel({ items }: Props) {
     tick();
   }
 
-  if (items.length === 0) return null;
+  if (items.length === 0 || !isClient) return null;
 
-  return (
+  // Portal to document.body so the FAB escapes <template>'s `transform`
+  // containing block — otherwise `position: fixed` anchors to the
+  // transformed page wrapper instead of the viewport.
+  return createPortal(
     <>
       <Button
         onClick={spin}
@@ -101,6 +110,7 @@ export function FoodWheel({ items }: Props) {
           </div>
         </DialogContent>
       </Dialog>
-    </>
+    </>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
FAB 黏在頁面最底（grid 結尾）而不是 viewport 右下角。根因：`app/template.tsx` 包了 `<div class="page-transition">`，這個 class 跑 `transform` 動畫 → 任何祖先有 transform 就建立新 containing block → `position: fixed` 改成相對於該 block。

修法：用 `createPortal` 把 FAB + Dialog mount 到 `document.body`，脫離 template 的 transform context。

## Test plan
- [x] Local build pass
- [ ] Scroll 頁面到底 / 中段，FAB 永遠 viewport 右下角

🤖 Generated with [Claude Code](https://claude.com/claude-code)