### PR TITLE
style(trending): unify card style with the rest of home grid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -95,7 +95,7 @@ export default async function HomePage({ searchParams }: Props) {
         ) : (
           <>
             {trending.length > 0 && (
-              <RecommendationSection title="🔥 熱銷排行" items={trending} accent />
+              <RecommendationSection title="🔥 熱銷排行" items={trending} />
             )}
 
             <section className="flex flex-col gap-3">

--- a/components/recommendation-section.tsx
+++ b/components/recommendation-section.tsx
@@ -1,45 +1,24 @@
-import Link from "next/link";
-import type { RecommendedItem } from "@/lib/recommendation";
+import { HomeItemCard } from "@/components/home-item-card";
+import type { HomeItem } from "@/lib/recommendation";
 
 interface Props {
   title: string;
-  items: RecommendedItem[];
-  accent?: boolean;
+  items: HomeItem[];
 }
 
-export default function RecommendationSection({ title, items, accent }: Props) {
+export default function RecommendationSection({ title, items }: Props) {
   if (items.length === 0) return null;
 
   return (
-    <div className="flex flex-col gap-3">
-      <h2 className="text-heading font-semibold flex items-center gap-2">
-        {accent && <span className="inline-block w-1 h-5 bg-brand rounded-full" aria-hidden />}
-        {title}
-      </h2>
-      <div className="flex overflow-x-auto gap-3 pb-2 snap-x snap-mandatory [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+    <section className="flex flex-col gap-3">
+      <h2 className="text-heading font-semibold">{title}</h2>
+      <div className="flex overflow-x-auto gap-4 pb-2 snap-x snap-mandatory [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         {items.map((item) => (
-          <Link
-            key={item.id}
-            href={`/menu/${item.vendor_id}`}
-            className="snap-start flex-shrink-0 w-48"
-          >
-            <div className="border rounded-card bg-card p-3 flex flex-col gap-2 h-full hover:scale-[1.02] transition-all duration-200">
-              <p className="text-heading-sm font-semibold leading-tight line-clamp-2">{item.name}</p>
-              <p className="text-meta text-muted-foreground">{item.vendor_name}</p>
-              <p className="text-body font-semibold mt-auto">NT${item.price}</p>
-              {item.tags.length > 0 && (
-                <div className="flex flex-wrap gap-1">
-                  {item.tags.slice(0, 3).map((tag) => (
-                    <span key={tag} className="text-caption border rounded-pill px-2 py-0.5 text-muted-foreground">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </Link>
+          <div key={item.id} className="snap-start flex-shrink-0 w-48">
+            <HomeItemCard item={item} />
+          </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -66,7 +66,7 @@ export async function getHomeItems(
   }));
 }
 
-export async function getTrendingItems(limit = 8, areaId?: string): Promise<RecommendedItem[]> {
+export async function getTrendingItems(limit = 8, areaId?: string): Promise<HomeItem[]> {
   const supabase = await createClient();
   const since = new Date(new Date().getTime() - 7 * 86400000).toISOString();
 
@@ -91,8 +91,8 @@ export async function getTrendingItems(limit = 8, areaId?: string): Promise<Reco
   if (topIds.length === 0) return [];
 
   const select = areaId
-    ? "id, name, price, description, tags, ai_tags, calories, protein, vendor_id, vendors!inner(name, vendor_areas!inner(area_id))"
-    : "id, name, price, description, tags, ai_tags, calories, protein, vendor_id, vendors(name)";
+    ? "id, name, price, description, image_url, tags, ai_tags, ai_description, calories, protein, sodium, vendor_id, vendors!inner(name, is_open, vendor_areas!inner(area_id))"
+    : "id, name, price, description, image_url, tags, ai_tags, ai_description, calories, protein, sodium, vendor_id, vendors(name, is_open)";
 
   let query = supabase
     .from("menu_items")
@@ -107,23 +107,30 @@ export async function getTrendingItems(limit = 8, areaId?: string): Promise<Reco
   if (!items) return [];
 
   return topIds
-    .map((id) => {
+    .map((id): HomeItem | null => {
       const item = items.find((i) => i.id === id);
       if (!item) return null;
       if ((item.ai_tags as string[] | null)?.includes("addon")) return null;
-      const vendor = item.vendors as { name: string } | null;
+      const vendor = item.vendors as { name: string; is_open: boolean } | null;
       return {
         id: item.id,
         name: item.name,
-        price: item.price,
         description: item.description,
-        tags: item.tags,
+        price: item.price,
+        image_url: item.image_url,
+        tags: item.tags ?? [],
+        ai_tags: item.ai_tags ?? [],
+        ai_description: item.ai_description,
         calories: item.calories,
         protein: item.protein,
+        sodium: item.sodium,
         vendor_id: item.vendor_id,
         vendor_name: vendor?.name ?? "",
+        vendor_is_open: vendor?.is_open ?? true,
+        match_score: 0,
+        top_tag_label: null,
       };
     })
-    .filter((x): x is RecommendedItem => x !== null);
+    .filter((x): x is HomeItem => x !== null);
 }
 


### PR DESCRIPTION
## Summary
- 熱銷排行 carousel 換成 `HomeItemCard`（之前是自己手寫的迷你 card 沒圖）
- 拿掉 section heading 左邊的 brand 橘色直條，emoji 自己當 anchor
- `getTrendingItems` 改 return `HomeItem[]`，SELECT 加 `image_url`/`ai_description`/`sodium`/`vendors.is_open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)