### PR TITLE
style(trending): match carousel card width to grid cells

### DIFF
--- a/components/recommendation-section.tsx
+++ b/components/recommendation-section.tsx
@@ -14,7 +14,10 @@ export default function RecommendationSection({ title, items }: Props) {
       <h2 className="text-heading font-semibold">{title}</h2>
       <div className="flex overflow-x-auto gap-4 pb-2 snap-x snap-mandatory [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         {items.map((item) => (
-          <div key={item.id} className="snap-start flex-shrink-0 w-48">
+          <div
+            key={item.id}
+            className="snap-start flex-shrink-0 w-[calc(50%-0.5rem)] md:w-[calc(33.333%-0.667rem)] lg:w-[calc(25%-0.75rem)]"
+          >
             <HomeItemCard item={item} />
           </div>
         ))}


### PR DESCRIPTION
## Summary
熱銷排行 card 用跟所有餐點 grid 一樣的 cell 寬度（之前 fixed w-48 比較窄）：
- mobile (`grid-cols-2 gap-4`) → `w-[calc(50%-0.5rem)]`
- md (`grid-cols-3 gap-4`) → `w-[calc(33.333%-0.667rem)]`
- lg (`grid-cols-4 gap-4`) → `w-[calc(25%-0.75rem)]`

Carousel 仍 horizontal scroll（items 多於可見 col）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)