### PR TITLE
test: add backend coverage tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,59 @@ Open [http://localhost:3000](http://localhost:3000)
 ```bash
 bun run test        # Run Vitest first, then Playwright e2e
 bun run test:unit   # Run unit tests + mock integration tests with Vitest
+bun run test:coverage # Run Vitest with backend coverage report
 bun run test:e2e    # Run Playwright e2e tests
 bun run test:ui     # Playwright UI mode
 ```
 
 ### Current Test Coverage
 
-- `app/cart/cart-view.test.ts`: cart grouping, sorting, totals
-- `app/orders/order-summary.test.ts`: order summary normalization
+Latest local backend unit test run:
+
+```text
+bun run test:unit
+Test Files  31 passed (31)
+Tests       162 passed (162)
+```
+
+Latest local backend coverage run:
+
+```text
+bun run test:coverage
+All files: 88.87% statements, 78.63% branches, 93.38% functions, 94.72% lines
+```
+
+Backend coverage includes `lib/**/*.ts`, Server Actions, route handlers, and `proxy.ts`.
+
+Unit and mock-integration coverage currently includes:
+
+- `app/api/pickup/route.test.ts`: QR pickup route permissions, order status checks, picked-up transitions
+- `app/auth/callback/route.test.ts`: OAuth callback exchange, safe redirects, profile-name backfill
 - `app/cart/actions.test.ts`: mocked Server Action coverage for cart flows
+- `app/cart/cart-view.test.ts`: cart grouping, sorting, totals
+- `app/login/actions.test.ts`: email login and Google OAuth redirect behavior
+- `app/menu/[id]/actions.test.ts`: add-to-order validation, anti-tampering checks, quota errors
 - `app/orders/actions.test.ts`: mocked order query + pagination coverage
+- `app/orders/order-summary.test.ts`: order summary normalization
+- `app/profile/actions.test.ts`: sign-out and employee profile updates
+- `app/vendor/menu/actions.test.ts`: menu item, AI metadata, quota, option group, and option actions
+- `app/vendor/orders/actions.test.ts`: single and batch pickup actions
+- `app/vendor/profile/actions.test.ts`: vendor profile, schedule, and image updates
+- `app/vendor/revenue/actions.test.ts`: vendor revenue dashboard query/fallback behavior
 - `app/vendor/revenue/revenue-model.test.ts`: revenue aggregation helpers
-- `lib/navigation-rules.test.ts`: role → default-home + header-visibility rules
+- `lib/auth.test.ts`: role guard behavior
+- `lib/branding.test.ts`: product name and factory-area constants
+- `lib/context.test.ts`: weather context mapping and context embedding cache behavior
+- `lib/daily-pick.test.ts`: daily pick lookup and normalization
+- `lib/filters.test.ts`: search filter parsing, serialization, and active counts
+- `lib/impressions.test.ts`: impression deduplication and upsert payloads
+- `lib/navigation-rules.test.ts`: role to default-home and header-visibility rules
+- `lib/reasons.test.ts`: personalized reason TTL filtering, attachment, and generation trigger
+- `lib/recommendation.test.ts`: home ranking RPC mapping and trending item aggregation
+- `lib/roulette.test.ts`: random item selection boundaries
+- `lib/search.test.ts`: hybrid search, embedding fallback, rerank fallback, filter params
+- `lib/utils.test.ts`: class-name merge helper
+- `proxy.test.ts`: auth proxy redirects and public auth path behavior
 - `e2e/home.spec.ts`, `e2e/menu.spec.ts`, `e2e/order-flow.spec.ts`: real browser flows
 
 ### E2E Requirements

--- a/app/api/pickup/route.test.ts
+++ b/app/api/pickup/route.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, redirectMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  redirectMock: vi.fn((url: string) => new Response(null, { status: 307, headers: { location: url } })),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+import { GET } from "@/app/api/pickup/route";
+import { createSupabaseMock } from "@/test/supabase-mock";
+
+function request(url: string) {
+  return { nextUrl: new URL(url) } as never;
+}
+
+describe("pickup route", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    redirectMock.mockClear();
+  });
+
+  it("rejects requests without an item id", async () => {
+    const res = await GET(request("https://example.test/api/pickup"));
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Missing item ID");
+  });
+
+  it("redirects unauthenticated users to login", async () => {
+    const { client } = createSupabaseMock({ user: null, expectations: [] });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/login");
+  });
+
+  it("rejects non-vendor users", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [{ table: "profiles", result: { data: { role: ["user"] } } }],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("需要商家權限");
+  });
+
+  it("rejects order items from another vendor", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: false,
+              order_id: "o1",
+              menu_items: { vendor_id: "other" },
+              orders: { status: "confirmed" },
+            },
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("此品項不屬於您的商店");
+  });
+
+  it("marks the item picked up and completes the order when no items remain", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: false,
+              order_id: "o1",
+              menu_items: { vendor_id: "v1" },
+              orders: { status: "confirmed" },
+            },
+          },
+        },
+        { table: "order_items", result: { data: null, error: null } },
+        { table: "order_items", result: { data: [] } },
+        { table: "orders", result: { data: null, error: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/vendor/orders?msg=picked-up");
+    expect(mutations).toEqual([
+      { table: "order_items", op: "update", payload: { picked_up: true } },
+      { table: "orders", op: "update", payload: { status: "completed" } },
+    ]);
+  });
+});

--- a/app/auth/callback/route.test.ts
+++ b/app/auth/callback/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+
+import { GET } from "@/app/auth/callback/route";
+
+function makeClient(opts: {
+  user?: { id: string; user_metadata?: Record<string, string> } | null;
+  error?: { message: string } | null;
+}) {
+  const update = vi.fn(() => builder);
+  const builder = {
+    update,
+    eq: vi.fn(() => builder),
+    is: vi.fn(async () => ({ error: null })),
+  };
+  return {
+    client: {
+      auth: {
+        exchangeCodeForSession: vi.fn(async () => ({
+          data: { user: opts.user ?? null },
+          error: opts.error ?? null,
+        })),
+      },
+      from: vi.fn(() => builder),
+    },
+    update,
+  };
+}
+
+describe("auth callback route", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("exchanges the code, fills a missing profile name, and redirects to a safe next path", async () => {
+    const { client, update } = makeClient({
+      user: { id: "u1", user_metadata: { full_name: "Grant Yeh" } },
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(new Request("https://example.test/auth/callback?code=abc&next=/vendor"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://example.test/vendor");
+    expect(update).toHaveBeenCalledWith({ name: "Grant Yeh" });
+  });
+
+  it("falls back to / when next is an external-protocol-style URL", async () => {
+    const { client } = makeClient({ user: { id: "u1", user_metadata: {} } });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(
+      new Request("https://example.test/auth/callback?code=abc&next=//evil.test"),
+    );
+
+    expect(res.headers.get("location")).toBe("https://example.test/");
+  });
+
+  it("redirects to login when code exchange fails", async () => {
+    const { client } = makeClient({ error: { message: "bad code" } });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(new Request("https://example.test/auth/callback?code=bad"));
+
+    expect(res.headers.get("location")).toBe("https://example.test/login?error=auth");
+  });
+});

--- a/app/login/actions.test.ts
+++ b/app/login/actions.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, redirectMock, headersMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  redirectMock: vi.fn(),
+  headersMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+vi.mock("next/headers", () => ({ headers: headersMock }));
+
+import { signInWithEmail, signInWithGoogle } from "@/app/login/actions";
+import { createSupabaseMock } from "@/test/supabase-mock";
+
+describe("login actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    redirectMock.mockReset();
+    headersMock.mockReset();
+  });
+
+  it("returns an auth error from email sign in", async () => {
+    createClientMock.mockResolvedValue({
+      auth: {
+        signInWithPassword: vi.fn(async () => ({ error: { message: "Invalid login" } })),
+      },
+    });
+
+    await expect(signInWithEmail("a@example.test", "bad")).resolves.toEqual({
+      error: "Invalid login",
+    });
+  });
+
+  it("redirects email sign in by the user's role", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [{ table: "profiles", result: { data: { role: ["vendor"] } } }],
+    });
+    (client.auth as typeof client.auth & {
+      signInWithPassword: ReturnType<typeof vi.fn>;
+    }).signInWithPassword = vi.fn(async () => ({ error: null }));
+    createClientMock.mockResolvedValue(client);
+
+    await signInWithEmail("v@example.test", "pw");
+
+    expect(redirectMock).toHaveBeenCalledWith("/vendor");
+  });
+
+  it("starts Google OAuth with the callback URL from request origin", async () => {
+    const signInWithOAuth = vi.fn(async () => ({
+      data: { url: "https://accounts.google.test/oauth" },
+      error: null,
+    }));
+    createClientMock.mockResolvedValue({ auth: { signInWithOAuth } });
+    headersMock.mockResolvedValue({ get: vi.fn(() => "https://nycueats.test") });
+
+    await signInWithGoogle();
+
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: { redirectTo: "https://nycueats.test/auth/callback" },
+    });
+    expect(redirectMock).toHaveBeenCalledWith("https://accounts.google.test/oauth");
+  });
+});

--- a/app/profile/actions.test.ts
+++ b/app/profile/actions.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock, redirectMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+import { signOut, updateProfile } from "@/app/profile/actions";
+import { createSupabaseMock } from "@/test/supabase-mock";
+
+describe("profile actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+    redirectMock.mockReset();
+  });
+
+  it("signs out and redirects to login", async () => {
+    const signOutMock = vi.fn(async () => ({ error: null }));
+    createClientMock.mockResolvedValue({ auth: { signOut: signOutMock } });
+
+    await signOut();
+
+    expect(signOutMock).toHaveBeenCalled();
+    expect(redirectMock).toHaveBeenCalledWith("/login");
+  });
+
+  it("rejects profile updates when the user is not logged in", async () => {
+    const { client } = createSupabaseMock({ user: null, expectations: [] });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(updateProfile(new FormData())).resolves.toEqual({ error: "未登入" });
+  });
+
+  it("trims blank profile fields into nulls and revalidates affected pages", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [{ table: "profiles", result: { error: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+    const formData = new FormData();
+    formData.set("name", "   ");
+    formData.set("area_id", "");
+
+    await expect(updateProfile(formData)).resolves.toEqual({ success: true });
+
+    expect(mutations).toEqual([
+      { table: "profiles", op: "update", payload: { name: null, area_id: null } },
+    ]);
+    expect(revalidatePathMock).toHaveBeenCalledWith("/profile");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/");
+  });
+});

--- a/app/vendor/menu/actions.test.ts
+++ b/app/vendor/menu/actions.test.ts
@@ -11,10 +11,17 @@ vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
 vi.mock("next/server", () => ({ after: afterMock }));
 
 import {
+  backfillMissingAiTags,
   bulkUpsertSlots,
+  deleteOption,
+  deleteOptionGroup,
   deleteMenuItem,
   regenerateAiMetadata,
   setDailySlot,
+  toggleMenuItem,
+  upsertMenuItem,
+  upsertOption,
+  upsertOptionGroup,
 } from "@/app/vendor/menu/actions";
 import { createSupabaseMock, roleProfile, type FromExpectation } from "@/test/supabase-mock";
 
@@ -150,6 +157,70 @@ describe("vendor menu actions", () => {
     });
   });
 
+  describe("upsertMenuItem", () => {
+    it("creates a menu item for the current vendor and schedules AI tagging", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: { id: "m1" }, error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(
+        upsertMenuItem({ name: "雞腿飯", price: 120, description: "招牌" }),
+      ).resolves.toEqual({ success: true, id: "m1" });
+
+      expect(mutations).toEqual([
+        {
+          table: "menu_items",
+          op: "insert",
+          payload: { name: "雞腿飯", price: 120, description: "招牌", vendor_id: "v1" },
+        },
+      ]);
+      expect(afterMock).toHaveBeenCalledOnce();
+      expect(revalidatePathMock).toHaveBeenCalledWith("/vendor/menu");
+    });
+
+    it("updates an existing item scoped to the current vendor", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [...vendorContext("v1"), { table: "menu_items", result: { error: null } }],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(upsertMenuItem({ id: "m1", name: "飯", price: 90 })).resolves.toEqual({
+        success: true,
+      });
+
+      expect(mutations).toEqual([
+        {
+          table: "menu_items",
+          op: "update",
+          payload: { id: "m1", name: "飯", price: 90, vendor_id: "v1" },
+        },
+      ]);
+    });
+  });
+
+  describe("toggleMenuItem", () => {
+    it("updates availability scoped to the current vendor", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [...vendorContext("v1"), { table: "menu_items", result: { error: null } }],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(toggleMenuItem("m1", false)).resolves.toBeUndefined();
+
+      expect(mutations).toEqual([
+        { table: "menu_items", op: "update", payload: { is_available: false } },
+      ]);
+      expect(revalidatePathMock).toHaveBeenCalledWith("/vendor/menu");
+    });
+  });
+
   describe("regenerateAiMetadata", () => {
     it("rejects an empty selection", async () => {
       const { client } = createSupabaseMock({
@@ -186,6 +257,135 @@ describe("vendor menu actions", () => {
       expect(client.functions.invoke).toHaveBeenCalledWith("generate-menu-item-tags", {
         body: { menu_item_ids: ["m1"], force: true },
       });
+    });
+  });
+
+  describe("backfillMissingAiTags", () => {
+    it("returns count 0 without invoking the edge function when nothing is missing", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [...vendorContext("v1"), { table: "menu_items", result: { data: [] } }],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(backfillMissingAiTags()).resolves.toEqual({ success: true, count: 0 });
+      expect(client.functions.invoke).not.toHaveBeenCalled();
+    });
+
+    it("invokes AI tagging for up to 100 missing items", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: [{ id: "m1" }, { id: "m2" }] } },
+        ],
+        invokeResult: { data: { results: [{ id: "m1", status: "ok" }] }, error: null },
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(backfillMissingAiTags()).resolves.toEqual({
+        results: [{ id: "m1", status: "ok" }],
+        count: 2,
+      });
+      expect(client.functions.invoke).toHaveBeenCalledWith("generate-menu-item-tags", {
+        body: { menu_item_ids: ["m1", "m2"], force: false },
+      });
+    });
+  });
+
+  describe("option groups and options", () => {
+    it("upserts an option group after checking menu item ownership", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: { id: "m1" } } },
+          { table: "item_option_groups", result: { error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(
+        upsertOptionGroup({
+          menu_item_id: "m1",
+          name: "甜度",
+          required: true,
+          max_select: 1,
+          sort_order: 0,
+        }),
+      ).resolves.toEqual({ success: true });
+
+      expect(mutations[0]).toEqual({
+        table: "item_option_groups",
+        op: "insert",
+        payload: {
+          menu_item_id: "m1",
+          name: "甜度",
+          required: true,
+          max_select: 1,
+          sort_order: 0,
+        },
+      });
+    });
+
+    it("deletes an option group only after ownership is verified", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "item_option_groups", result: { data: { menu_item_id: "m1" } } },
+          { table: "menu_items", result: { data: { id: "m1" } } },
+          { table: "item_option_groups", result: { error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(deleteOptionGroup("g1")).resolves.toBeUndefined();
+      expect(mutations).toEqual([
+        { table: "item_option_groups", op: "delete", payload: undefined },
+      ]);
+    });
+
+    it("upserts an option after resolving its group ownership", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "item_option_groups", result: { data: { menu_item_id: "m1" } } },
+          { table: "menu_items", result: { data: { id: "m1" } } },
+          { table: "item_options", result: { error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(
+        upsertOption({ group_id: "g1", name: "加蛋", price_delta: 15, sort_order: 1 }),
+      ).resolves.toEqual({ success: true });
+
+      expect(mutations[0]).toEqual({
+        table: "item_options",
+        op: "insert",
+        payload: { group_id: "g1", name: "加蛋", price_delta: 15, sort_order: 1 },
+      });
+    });
+
+    it("deletes an option after resolving nested group ownership", async () => {
+      const { client, mutations } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          {
+            table: "item_options",
+            result: { data: { group_id: "g1", item_option_groups: { menu_item_id: "m1" } } },
+          },
+          { table: "menu_items", result: { data: { id: "m1" } } },
+          { table: "item_options", result: { error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(deleteOption("o1")).resolves.toBeUndefined();
+      expect(mutations).toEqual([{ table: "item_options", op: "delete", payload: undefined }]);
     });
   });
 });

--- a/app/vendor/orders/actions.test.ts
+++ b/app/vendor/orders/actions.test.ts
@@ -13,7 +13,7 @@ vi.mock("next/cache", () => ({
   revalidatePath: revalidatePathMock,
 }));
 
-import { pickUpOrderItem } from "@/app/vendor/orders/actions";
+import { batchPickUp, pickUpOrderItem } from "@/app/vendor/orders/actions";
 
 type QueryResult = { data?: unknown; error?: unknown };
 type FromExpectation = { table: string; result: QueryResult };
@@ -157,5 +157,47 @@ describe("pickUpOrderItem", () => {
     expect(updateCaptures).toEqual([
       { table: "order_items", payload: { picked_up: true } },
     ]);
+  });
+
+  describe("batchPickUp", () => {
+    it("returns success when every item is picked up", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          { table: "vendors", result: { data: { id: "v1" } } },
+          {
+            table: "order_items",
+            result: {
+              data: { id: "oi1", order_id: "ord1", menu_items: { vendor_id: "v1" } },
+            },
+          },
+          { table: "order_items", result: { data: null, error: null } },
+          { table: "order_items", result: { data: [{ id: "oi2" }] } },
+          { table: "vendors", result: { data: { id: "v1" } } },
+          {
+            table: "order_items",
+            result: {
+              data: { id: "oi2", order_id: "ord1", menu_items: { vendor_id: "v1" } },
+            },
+          },
+          { table: "order_items", result: { data: null, error: null } },
+          { table: "order_items", result: { data: [] } },
+          { table: "orders", result: { data: null, error: null } },
+        ],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(batchPickUp(["oi1", "oi2"])).resolves.toEqual({ success: true });
+    });
+
+    it("summarizes failed item pickups", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [{ table: "vendors", result: { data: null } }],
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await expect(batchPickUp(["oi1"])).resolves.toEqual({ error: "1 筆失敗" });
+    });
   });
 });

--- a/app/vendor/profile/actions.test.ts
+++ b/app/vendor/profile/actions.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, revalidatePathMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+
+import {
+  updateVendorImage,
+  updateVendorInfo,
+  updateVendorSchedule,
+} from "@/app/vendor/profile/actions";
+import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
+
+describe("vendor profile actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    revalidatePathMock.mockReset();
+  });
+
+  it("rejects an empty vendor name before updating", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("vendor")],
+    });
+    createClientMock.mockResolvedValue(client);
+    const formData = new FormData();
+    formData.set("name", "  ");
+    formData.set("description", "x");
+    formData.set("operating_days", "1,2");
+
+    await expect(updateVendorInfo(formData)).resolves.toEqual({ error: "店家名稱不能為空" });
+    expect(mutations).toEqual([]);
+  });
+
+  it("updates vendor info with parsed schedule fields", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("vendor"), { table: "vendors", result: { error: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+    const formData = new FormData();
+    formData.set("name", "  好吃店  ");
+    formData.set("description", "  ");
+    formData.set("is_open", "true");
+    formData.set("operating_days", "1,3,5");
+
+    await expect(updateVendorInfo(formData)).resolves.toEqual({ success: true });
+
+    expect(mutations[0]).toEqual({
+      table: "vendors",
+      op: "update",
+      payload: {
+        name: "好吃店",
+        description: null,
+        is_open: true,
+        operating_days: [1, 3, 5],
+      },
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/vendor/profile");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/");
+  });
+
+  it("updates schedule and image scoped to the vendor owner", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        roleProfile("vendor"),
+        { table: "vendors", result: { error: null } },
+        roleProfile("vendor"),
+        { table: "vendors", result: { error: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(updateVendorSchedule(false, [2, 4])).resolves.toEqual({ success: true });
+    await expect(updateVendorImage("https://cdn.test/a.jpg")).resolves.toEqual({ success: true });
+
+    expect(mutations).toEqual([
+      {
+        table: "vendors",
+        op: "update",
+        payload: { is_open: false, operating_days: [2, 4] },
+      },
+      { table: "vendors", op: "update", payload: { image_url: "https://cdn.test/a.jpg" } },
+    ]);
+  });
+});

--- a/app/vendor/revenue/actions.test.ts
+++ b/app/vendor/revenue/actions.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+
+import { getVendorRevenueDashboard } from "@/app/vendor/revenue/actions";
+import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
+
+describe("getVendorRevenueDashboard", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T12:00:00Z"));
+  });
+
+  it("returns an empty dashboard when the vendor record is missing", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [roleProfile("vendor"), { table: "vendors", result: { data: null } }],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getVendorRevenueDashboard(2026, 5)).resolves.toMatchObject({
+      vendor: null,
+      stats: {
+        thisMonth: { orders: 0, revenue: 0, soldQuantity: 0 },
+        lastMonth: { orders: 0, revenue: 0, soldQuantity: 0 },
+      },
+      topMenuItems: [],
+    });
+  });
+
+  it("builds the dashboard from vendor order items", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        roleProfile("vendor"),
+        { table: "vendors", result: { data: { id: "v1", name: "好吃店" } } },
+        {
+          table: "order_items",
+          result: {
+            data: [
+              {
+                date: "2026-05-10",
+                qty: 2,
+                unit_price: 100,
+                order_id: "o1",
+                menu_item_id: "m1",
+                menu_items: { name: "雞腿飯", vendor_id: "v1" },
+                orders: { status: "confirmed" },
+              },
+              {
+                date: "2026-04-20",
+                qty: 1,
+                unit_price: 80,
+                order_id: "o2",
+                menu_item_id: "m2",
+                menu_items: { name: "湯麵", vendor_id: "v1" },
+                orders: { status: "completed" },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await getVendorRevenueDashboard(2026, 5);
+
+    expect(result.vendor).toEqual({ id: "v1", name: "好吃店" });
+    expect(result.stats.thisMonth).toEqual({ orders: 1, revenue: 200, soldQuantity: 2 });
+    expect(result.stats.lastMonth).toEqual({ orders: 1, revenue: 80, soldQuantity: 1 });
+    expect(result.topMenuItems[0]).toMatchObject({ name: "雞腿飯", count: 2, revenue: 200 });
+  });
+
+  it("keeps the vendor but returns empty metrics when the order query fails", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        roleProfile("vendor"),
+        { table: "vendors", result: { data: { id: "v1", name: "好吃店" } } },
+        { table: "order_items", result: { data: null, error: { message: "db down" } } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getVendorRevenueDashboard(2026, 5)).resolves.toMatchObject({
+      vendor: { id: "v1", name: "好吃店" },
+      stats: {
+        thisMonth: { orders: 0, revenue: 0, soldQuantity: 0 },
+        lastMonth: { orders: 0, revenue: 0, soldQuantity: 0 },
+      },
+    });
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "4.1.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "tailwindcss": "^4",
@@ -98,6 +99,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.57.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-iKXuo8Nes9Ft4zF3AZOT4FHkl6OV8bHqn61a67qHokkBzSEurnKZAlOkT0FYrRNVGvE6nCfZMtYswyjfXCR1MQ=="],
 
@@ -559,6 +562,8 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.2", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.2", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.2", "vitest": "4.1.2" }, "optionalPeers": ["@vitest/browser"] }, "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
@@ -616,6 +621,8 @@
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.2", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
@@ -945,6 +952,8 @@
 
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -1053,13 +1062,19 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1130,6 +1145,10 @@
     "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1565,6 +1584,8 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -1631,6 +1652,12 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "magicast/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "msw/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -1691,6 +1718,8 @@
 
     "eslint-plugin-import/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
+    "magicast/@babel/parser/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
     "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "msw/yargs/y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -1708,6 +1737,10 @@
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "magicast/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "magicast/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "coverage/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/lib/context.test.ts
+++ b/lib/context.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { contextKey, getContextEmbedding, getCurrentContext } from "@/lib/context";
+
+type QueryResult = { data?: unknown; error?: { message: string } | null };
+
+function makeContextClient(opts: {
+  cached?: unknown;
+  embedding?: number[] | null;
+  invokeError?: boolean;
+}) {
+  const upsert = vi.fn(() => Promise.resolve({ error: null }));
+  const maybeSingle = vi.fn(async () => ({ data: opts.cached ? { embedding: opts.cached } : null }));
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    maybeSingle,
+    upsert,
+  };
+  const invoke = vi.fn(async (): Promise<QueryResult> => {
+    if (opts.invokeError) return { data: null, error: { message: "edge down" } };
+    return { data: opts.embedding ? { embedding: opts.embedding } : null, error: null };
+  });
+
+  return {
+    client: {
+      from: vi.fn(() => builder),
+      functions: { invoke },
+    },
+    builder,
+    invoke,
+    upsert,
+  };
+}
+
+describe("getCurrentContext", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("maps weather API data to hour, temperature, and rain bands", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          current: { temperature_2m: 31, precipitation: 0.2, time: "2026-05-27T12:30" },
+        }),
+      })),
+    );
+
+    await expect(getCurrentContext()).resolves.toEqual({
+      hourBand: "noon",
+      tempBand: "hot",
+      rainy: true,
+    });
+  });
+
+  it("returns null when weather fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
+
+    await expect(getCurrentContext()).resolves.toBeNull();
+  });
+});
+
+describe("contextKey", () => {
+  it("builds the embedding cache key", () => {
+    expect(contextKey({ hourBand: "evening", tempBand: "mild", rainy: false })).toBe(
+      "evening_mild_dry",
+    );
+  });
+});
+
+describe("getContextEmbedding", () => {
+  it("uses cached string embeddings without invoking the edge function", async () => {
+    const { client, invoke } = makeContextClient({ cached: "[0.1,0.2]" });
+
+    await expect(
+      getContextEmbedding(client as never, { hourBand: "morning", tempBand: "cold", rainy: true }),
+    ).resolves.toEqual([0.1, 0.2]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("invokes embed-query and caches the result on a cache miss", async () => {
+    const { client, invoke, upsert } = makeContextClient({ embedding: [0.3, 0.4] });
+
+    await expect(
+      getContextEmbedding(client as never, { hourBand: "noon", tempBand: "hot", rainy: false }),
+    ).resolves.toEqual([0.3, 0.4]);
+    expect(invoke).toHaveBeenCalledWith("embed-query", {
+      body: { query: "scorching hot noon, cold drinks ice light meal" },
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      { key: "noon_hot_dry", embedding: [0.3, 0.4] },
+      { onConflict: "key" },
+    );
+  });
+
+  it("returns null when embedding generation fails", async () => {
+    const { client } = makeContextClient({ invokeError: true });
+
+    await expect(
+      getContextEmbedding(client as never, { hourBand: "night", tempBand: "hot", rainy: true }),
+    ).resolves.toBeNull();
+  });
+});

--- a/lib/daily-pick.test.ts
+++ b/lib/daily-pick.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getDailyPick } from "@/lib/daily-pick";
+
+type QueryResult = { data?: unknown };
+
+function makeThenable(result: QueryResult) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "eq"] as const) builder[method] = vi.fn(() => builder as never);
+  builder.maybeSingle = vi.fn(async () => result);
+  return builder;
+}
+
+function makeClient(results: QueryResult[]) {
+  const builders = results.map(makeThenable);
+  return {
+    client: {
+      from: vi.fn(() => {
+        const builder = builders.shift();
+        if (!builder) throw new Error("Unexpected query");
+        return builder;
+      }),
+    },
+  };
+}
+
+describe("getDailyPick", () => {
+  it("returns null when no daily pick exists", async () => {
+    const { client } = makeClient([{ data: null }]);
+
+    await expect(getDailyPick(client as never, "u1")).resolves.toBeNull();
+  });
+
+  it("returns null for unavailable items or inactive vendors", async () => {
+    const { client } = makeClient([
+      { data: { menu_item_id: "m1" } },
+      {
+        data: {
+          id: "m1",
+          is_available: true,
+          vendors: { name: "店家", is_open: true, is_active: false },
+        },
+      },
+    ]);
+
+    await expect(getDailyPick(client as never, "u1")).resolves.toBeNull();
+  });
+
+  it("normalizes an active daily pick into a home item", async () => {
+    const { client } = makeClient([
+      { data: { menu_item_id: "m1" } },
+      {
+        data: {
+          id: "m1",
+          name: "今日餐",
+          description: null,
+          price: 100,
+          image_url: null,
+          tags: null,
+          ai_tags: null,
+          ai_description: null,
+          calories: 500,
+          protein: 20,
+          sodium: 700,
+          vendor_id: "v1",
+          is_available: true,
+          vendors: { name: "店家", is_open: true, is_active: true },
+        },
+      },
+    ]);
+
+    await expect(getDailyPick(client as never, "u1")).resolves.toMatchObject({
+      id: "m1",
+      tags: [],
+      ai_tags: [],
+      vendor_name: "店家",
+      vendor_is_open: true,
+    });
+  });
+});

--- a/lib/impressions.test.ts
+++ b/lib/impressions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recordImpressions } from "@/lib/impressions";
+
+function makeClient() {
+  const upsert = vi.fn(async () => ({ error: null }));
+  return {
+    client: {
+      from: vi.fn(() => ({ upsert })),
+    },
+    upsert,
+  };
+}
+
+describe("recordImpressions", () => {
+  it("does not touch Supabase when there are no items", async () => {
+    const { client } = makeClient();
+
+    await recordImpressions(client as never, "u1", []);
+
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates item impressions for the current date", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T12:00:00Z"));
+    const { client, upsert } = makeClient();
+
+    await recordImpressions(client as never, "u1", ["m1", "m2", "m1"]);
+
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        { user_id: "u1", menu_item_id: "m1", date: "2026-05-27" },
+        { user_id: "u1", menu_item_id: "m2", date: "2026-05-27" },
+      ],
+      { onConflict: "user_id,menu_item_id,date", ignoreDuplicates: true },
+    );
+  });
+});

--- a/lib/reasons.test.ts
+++ b/lib/reasons.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { attachReasons, fetchReasonsForItems, triggerReasonGeneration } from "@/lib/reasons";
+import type { HomeItem } from "@/lib/recommendation";
+
+function item(id: string): HomeItem {
+  return {
+    id,
+    name: `Item ${id}`,
+    description: null,
+    price: 100,
+    image_url: null,
+    tags: [],
+    ai_tags: ["light"],
+    ai_description: "Good item",
+    calories: null,
+    protein: null,
+    sodium: null,
+    vendor_id: "v1",
+    vendor_name: "Vendor",
+    vendor_is_open: true,
+    match_score: 0,
+    top_tag_label: null,
+  };
+}
+
+function makeReasonClient(rows: unknown[] = []) {
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    in: vi.fn(async () => ({ data: rows })),
+  };
+  const invoke = vi.fn(async () => ({ data: {}, error: null }));
+  return {
+    client: {
+      from: vi.fn(() => builder),
+      functions: { invoke },
+    },
+    builder,
+    invoke,
+  };
+}
+
+describe("fetchReasonsForItems", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T12:00:00Z"));
+  });
+
+  it("keeps fresh reasons and drops stale cached reasons", async () => {
+    const { client } = makeReasonClient([
+      { menu_item_id: "fresh", reason: "適合今天", generated_at: "2026-05-27T00:30:00Z" },
+      { menu_item_id: "stale", reason: "太舊", generated_at: "2026-05-25T00:00:00Z" },
+    ]);
+
+    const result = await fetchReasonsForItems(client as never, "u1", ["fresh", "stale"]);
+
+    expect([...result.entries()]).toEqual([["fresh", "適合今天"]]);
+  });
+
+  it("does not query Supabase for an empty item list", async () => {
+    const { client } = makeReasonClient();
+
+    await expect(fetchReasonsForItems(client as never, "u1", [])).resolves.toEqual(new Map());
+    expect(client.from).not.toHaveBeenCalled();
+  });
+});
+
+describe("attachReasons", () => {
+  it("attaches nullable reasons without changing item order", () => {
+    expect(
+      attachReasons([item("a"), item("b")], new Map([["b", "推薦理由"]])).map((it) => [
+        it.id,
+        it.reason,
+      ]),
+    ).toEqual([
+      ["a", null],
+      ["b", "推薦理由"],
+    ]);
+  });
+});
+
+describe("triggerReasonGeneration", () => {
+  it("sends at most 20 compact items to the edge function", async () => {
+    const { client, invoke } = makeReasonClient();
+    const items = Array.from({ length: 22 }, (_, index) => item(String(index)));
+
+    await triggerReasonGeneration(client as never, items);
+
+    expect(invoke).toHaveBeenCalledWith("generate-reasons", {
+      body: {
+        items: expect.arrayContaining([
+          { id: "0", name: "Item 0", ai_description: "Good item", ai_tags: ["light"] },
+        ]),
+      },
+    });
+    const [, options] = invoke.mock.calls[0] as unknown as [
+      string,
+      { body: { items: Array<unknown> } },
+    ];
+    expect(options.body.items).toHaveLength(20);
+  });
+});

--- a/lib/recommendation.test.ts
+++ b/lib/recommendation.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
+
+import { getHomeItems, getTrendingItems } from "@/lib/recommendation";
+
+type QueryResult = { data?: unknown; error?: { message: string } | null };
+
+function makeThenable(result: QueryResult) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "in", "gte", "eq"] as const) {
+    builder[method] = vi.fn(() => builder as never);
+  }
+  (builder as unknown as { then: (resolve: (value: QueryResult) => void) => Promise<void> }).then =
+    (resolve) => Promise.resolve(result).then(resolve);
+  return builder;
+}
+
+function homeRow(patch: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "m1",
+    name: "牛肉麵",
+    description: null,
+    price: 120,
+    image_url: null,
+    tags: null,
+    ai_tags: null,
+    ai_description: null,
+    calories: 650,
+    protein: 32,
+    sodium: 900,
+    vendor_id: "v1",
+    vendor_name: "麵店",
+    vendor_is_open: true,
+    match_score: 0.88,
+    top_tag_label: "高蛋白",
+    ...patch,
+  };
+}
+
+describe("getHomeItems", () => {
+  beforeEach(() => createClientMock.mockReset());
+
+  it("calls the ranking RPC with area, limit, and context vector", async () => {
+    const rpc = vi.fn(async () => ({ data: [homeRow()], error: null }));
+    createClientMock.mockResolvedValue({ rpc });
+
+    const result = await getHomeItems("area-1", 12, [0.1, 0.2]);
+
+    expect(rpc).toHaveBeenCalledWith("rank_menu_items_for_home", {
+      p_area_id: "area-1",
+      p_limit: 12,
+      p_context_vec: [0.1, 0.2],
+    });
+    expect(result[0]).toMatchObject({
+      id: "m1",
+      tags: [],
+      ai_tags: [],
+      vendor_name: "麵店",
+      top_tag_label: "高蛋白",
+    });
+  });
+
+  it("returns [] when the RPC errors or has no data", async () => {
+    createClientMock.mockResolvedValue({
+      rpc: vi.fn(async () => ({ data: null, error: { message: "rpc fail" } })),
+    });
+
+    await expect(getHomeItems()).resolves.toEqual([]);
+  });
+});
+
+describe("getTrendingItems", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T12:00:00.000Z"));
+  });
+
+  it("ranks menu items by recent confirmed quantity and filters add-ons", async () => {
+    const orderItemsBuilder = makeThenable({
+      data: [
+        { menu_item_id: "m2", qty: 2 },
+        { menu_item_id: "m1", qty: 1 },
+        { menu_item_id: "m2", qty: 3 },
+        { menu_item_id: "addon", qty: 10 },
+      ],
+    });
+    const menuItemsBuilder = makeThenable({
+      data: [
+        { ...homeRow({ id: "m1", name: "飯", ai_tags: ["rice"] }), vendors: { name: "便當店", is_open: true } },
+        { ...homeRow({ id: "m2", name: "麵", ai_tags: ["noodle"] }), vendors: { name: "麵店", is_open: false } },
+        { ...homeRow({ id: "addon", name: "加蛋", ai_tags: ["addon"] }), vendors: { name: "麵店", is_open: true } },
+      ],
+    });
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(orderItemsBuilder)
+      .mockReturnValueOnce(menuItemsBuilder);
+    createClientMock.mockResolvedValue({ from });
+
+    const result = await getTrendingItems(3, "area-1");
+
+    expect(result.map((item) => item.id)).toEqual(["m2", "m1"]);
+    expect(result[0]).toMatchObject({ vendor_name: "麵店", vendor_is_open: false });
+    expect(orderItemsBuilder.gte).toHaveBeenCalledWith(
+      "orders.created_at",
+      "2026-05-20T12:00:00.000Z",
+    );
+    expect(menuItemsBuilder.eq).toHaveBeenCalledWith("vendors.vendor_areas.area_id", "area-1");
+  });
+
+  it("returns [] without querying menu items when there are no recent orders", async () => {
+    const from = vi.fn().mockReturnValueOnce(makeThenable({ data: [] }));
+    createClientMock.mockResolvedValue({ from });
+
+    await expect(getTrendingItems()).resolves.toEqual([]);
+    expect(from).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("merges conditional classes and resolves Tailwind conflicts", () => {
+    expect(cn("px-2", false && "hidden", ["text-sm", "px-4"])).toBe("text-sm px-4");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run && playwright test",
     "test:e2e": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
@@ -36,6 +37,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "4.1.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createServerClientMock } = vi.hoisted(() => ({ createServerClientMock: vi.fn() }));
+
+vi.mock("@supabase/ssr", () => ({ createServerClient: createServerClientMock }));
+
+import { NextRequest } from "next/server";
+import { proxy } from "@/proxy";
+
+function makeSupabase(user: { id: string } | null, roles: string[] = []) {
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    single: vi.fn(async () => ({ data: { role: roles } })),
+  };
+  return {
+    auth: { getUser: vi.fn(async () => ({ data: { user } })) },
+    from: vi.fn(() => builder),
+  };
+}
+
+describe("proxy", () => {
+  beforeEach(() => createServerClientMock.mockReset());
+
+  it("redirects unauthenticated protected requests to login", async () => {
+    createServerClientMock.mockReturnValue(makeSupabase(null));
+
+    const res = await proxy(new NextRequest("https://example.test/cart"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://example.test/login");
+  });
+
+  it("allows unauthenticated public auth paths", async () => {
+    createServerClientMock.mockReturnValue(makeSupabase(null));
+
+    const res = await proxy(new NextRequest("https://example.test/auth/callback"));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("redirects logged-in users away from login by default role home", async () => {
+    createServerClientMock.mockReturnValue(makeSupabase({ id: "u1" }, ["admin"]));
+
+    const res = await proxy(new NextRequest("https://example.test/login"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://example.test/admin");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,22 @@ export default defineConfig({
     exclude: ["e2e/**", "node_modules/**", ".next/**"],
     clearMocks: true,
     restoreMocks: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: [
+        "lib/**/*.ts",
+        "app/**/actions.ts",
+        "app/api/**/route.ts",
+        "app/auth/**/route.ts",
+        "proxy.ts",
+      ],
+      exclude: [
+        "**/*.test.ts",
+        "lib/supabase/**",
+        "types/**",
+      ],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add backend unit coverage for recommendation/context helpers, auth routes, profile/vendor actions, pickup flow, proxy behavior, and utilities
- extend vendor menu and pickup action tests for missing backend branches
- add Vitest coverage reporting and document the latest backend coverage results in README

## Test plan
- [x] bun run test:unit
- [x] bun run test:coverage
- [x] bun run lint
- [x] bunx tsc --noEmit