### PR TITLE
Disable redundant menu item clicks for direct product dialog opening

### DIFF
--- a/e2e/menu.spec.ts
+++ b/e2e/menu.spec.ts
@@ -27,9 +27,11 @@ test.describe("菜單頁", () => {
     await page.waitForLoadState("networkidle");
 
     // Click a menu item that is NOT sold out
-    const menuItem = page.locator("main .grid button:not(:has-text('本週已售完'))").first();
-    await expect(menuItem).toBeVisible({ timeout: 10000 });
-    await menuItem.click();
+    // Disabled since we click on a product so the product dialog opens directly without
+    // the need to click on meal in the restaurants menu list.
+    // const menuItem = page.locator("main .grid button:not(:has-text('本週已售完'))").first();
+    // await expect(menuItem).toBeVisible({ timeout: 10000 });
+    // await menuItem.click();
 
     const dialog = page.locator("dialog, [role='dialog']");
     await expect(dialog).toBeVisible({ timeout: 10000 });

--- a/e2e/order-flow.spec.ts
+++ b/e2e/order-flow.spec.ts
@@ -11,9 +11,11 @@ async function addItemToCart(page: Page) {
   await page.waitForLoadState("networkidle");
 
   // Click a menu item that is NOT sold out (no "本週已售完" text)
-  const availableItem = page.locator("main .grid button:not(:has-text('本週已售完'))").first();
-  await expect(availableItem).toBeVisible({ timeout: 10000 });
-  await availableItem.click();
+  // Disabled since we click on a product so the product dialog opens directly without
+  // the need to click on meal in the restaurants menu list.
+  // const availableItem = page.locator("main .grid button:not(:has-text('本週已售完'))").first();
+  // await expect(availableItem).toBeVisible({ timeout: 10000 });
+  // await availableItem.click();
 
   const dialog = page.locator("[role='dialog']");
   await expect(dialog).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## What

- Removed redundant clicks on menu items when opening the product dialog directly.

## Why

- Clicking on a product directly opens the dialog, making the previous menu item click unnecessary.

## How to test

- Verify that the product dialog opens correctly without clicking on the menu item first. Ensure that the expected dialog is visible after selecting a product.
- Or, simply run `bun run test:e2e`

