### PR TITLE
feat: deepen Sentry instrumentation (user context, business errors, spans, feedback, webhook)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,5 @@ SENTRY_DSN=
 # Build-time source map upload only (keep secret, not needed at runtime).
 # Generate at https://zyx1121.sentry.io/settings/auth-tokens/ with org:read + project:releases scopes
 SENTRY_AUTH_TOKEN=
+# Shared secret to verify Sentry alert webhooks at /api/sentry-alert-webhook (§5.4 alert-driven trigger)
+SENTRY_WEBHOOK_SECRET=

--- a/app/api/pickup/route.ts
+++ b/app/api/pickup/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { type NextRequest } from "next/server";
+import { captureActionError, identifyUser } from "@/lib/observability";
 
 export async function GET(request: NextRequest) {
   const itemId = request.nextUrl.searchParams.get("item");
@@ -20,6 +21,7 @@ export async function GET(request: NextRequest) {
   if (!profile?.role?.includes("vendor")) {
     return new Response("需要商家權限", { status: 403 });
   }
+  identifyUser(user, profile.role);
 
   const { data: vendor } = await supabase
     .from("vendors")
@@ -48,7 +50,18 @@ export async function GET(request: NextRequest) {
     return redirect("/vendor/orders?msg=already-picked-up");
   }
 
-  await supabase.from("order_items").update({ picked_up: true }).eq("id", itemId);
+  const { error: pickupError } = await supabase
+    .from("order_items")
+    .update({ picked_up: true })
+    .eq("id", itemId);
+  if (pickupError) {
+    captureActionError(pickupError, {
+      action: "pickup",
+      tags: { step: "mark_picked_up", vendor_id: vendor.id },
+      extra: { itemId, orderId: orderItem.order_id },
+    });
+    return new Response("核銷失敗，請稍後再試", { status: 500 });
+  }
 
   // Check if all items in the order are picked up → complete the order
   const { data: remaining } = await supabase
@@ -58,7 +71,17 @@ export async function GET(request: NextRequest) {
     .eq("picked_up", false);
 
   if (!remaining || remaining.length === 0) {
-    await supabase.from("orders").update({ status: "completed" }).eq("id", orderItem.order_id);
+    const { error: completeError } = await supabase
+      .from("orders")
+      .update({ status: "completed" })
+      .eq("id", orderItem.order_id);
+    if (completeError) {
+      captureActionError(completeError, {
+        action: "pickup",
+        tags: { step: "complete_order", vendor_id: vendor.id },
+        extra: { orderId: orderItem.order_id },
+      });
+    }
   }
 
   return redirect("/vendor/orders?msg=picked-up");

--- a/app/api/sentry-alert-webhook/route.ts
+++ b/app/api/sentry-alert-webhook/route.ts
@@ -1,0 +1,43 @@
+import * as Sentry from "@sentry/nextjs";
+import { createHmac, timingSafeEqual } from "crypto";
+import { type NextRequest } from "next/server";
+
+// Receiving end of the design doc's §5.4 "Alert-Driven" trigger: Sentry fires a
+// webhook on a new error / error-rate spike, the Autonomous Metrics Agent picks
+// it up here and starts its observe → analyze → act loop. This is the endpoint
+// stub — it verifies the signature and acknowledges; the agent hand-off is TODO.
+export async function POST(request: NextRequest) {
+  const raw = await request.text();
+  const secret = process.env.SENTRY_WEBHOOK_SECRET;
+
+  // Sentry signs the raw body with the integration's client secret (HMAC-SHA256).
+  if (secret) {
+    const expected = createHmac("sha256", secret).update(raw).digest("hex");
+    const got = request.headers.get("sentry-hook-signature") ?? "";
+    const a = Buffer.from(got);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      return new Response("invalid signature", { status: 401 });
+    }
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return new Response("invalid json", { status: 400 });
+  }
+
+  const resource = request.headers.get("sentry-hook-resource") ?? "unknown";
+  Sentry.addBreadcrumb({
+    category: "sentry.webhook",
+    level: "info",
+    message: `received ${resource} webhook`,
+  });
+
+  // TODO(§5.4): hand `payload` to the Autonomous Metrics Agent (read metrics →
+  // LLM analyze → open GitHub issue / PR). For now just acknowledge receipt.
+  console.log(`[sentry-webhook] ${resource}`, payload);
+
+  return Response.json({ received: true, resource });
+}

--- a/app/cart/actions.ts
+++ b/app/cart/actions.ts
@@ -2,11 +2,13 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import { captureActionError, identifyUser } from "@/lib/observability";
 
 export async function removeOrderItem(orderItemId: string) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: "未登入" };
+  identifyUser(user);
 
   const { data: item } = await supabase
     .from("order_items")
@@ -22,7 +24,10 @@ export async function removeOrderItem(orderItemId: string) {
     .delete()
     .eq("id", orderItemId);
 
-  if (error) return { error: "取消失敗" };
+  if (error) {
+    captureActionError(error, { action: "removeOrderItem", extra: { orderItemId } });
+    return { error: "取消失敗" };
+  }
   revalidatePath("/cart");
   return { success: true };
 }
@@ -31,6 +36,7 @@ export async function confirmOrder(orderId: string) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: "未登入" };
+  identifyUser(user);
 
   const { data: order } = await supabase
     .from("orders")
@@ -54,7 +60,14 @@ export async function confirmOrder(orderId: string) {
     .update({ status: "confirmed" })
     .eq("id", orderId);
 
-  if (error) return { error: "確認失敗" };
+  if (error) {
+    captureActionError(error, {
+      action: "confirmOrder",
+      tags: { step: "update_status" },
+      extra: { orderId },
+    });
+    return { error: "確認失敗" };
+  }
   revalidatePath("/cart");
   revalidatePath("/orders");
   return { success: true };
@@ -64,6 +77,7 @@ export async function cancelOrder(orderId: string) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: "未登入" };
+  identifyUser(user);
 
   const { data: order } = await supabase
     .from("orders")
@@ -80,14 +94,28 @@ export async function cancelOrder(orderId: string) {
     .delete()
     .eq("order_id", orderId);
 
-  if (itemsError) return { error: "清空失敗" };
+  if (itemsError) {
+    captureActionError(itemsError, {
+      action: "cancelOrder",
+      tags: { step: "delete_items" },
+      extra: { orderId },
+    });
+    return { error: "清空失敗" };
+  }
 
   const { error } = await supabase
     .from("orders")
     .update({ status: "cancelled" })
     .eq("id", orderId);
 
-  if (error) return { error: "取消失敗" };
+  if (error) {
+    captureActionError(error, {
+      action: "cancelOrder",
+      tags: { step: "update_status" },
+      extra: { orderId },
+    });
+    return { error: "取消失敗" };
+  }
   revalidatePath("/cart");
   revalidatePath("/orders");
   return { success: true };

--- a/app/menu/[id]/actions.ts
+++ b/app/menu/[id]/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import * as Sentry from "@sentry/nextjs";
 import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { captureActionError, identifyUser } from "@/lib/observability";
 
 export async function addToOrder(
   vendorId: string,
@@ -11,114 +13,144 @@ export async function addToOrder(
   qty: number,
   optionIds: string[] = []
 ) {
-  if (!Number.isInteger(qty) || qty < 1 || qty > 50) return { error: "數量錯誤" };
+  return Sentry.withServerActionInstrumentation(
+    "addToOrder",
+    {},
+    async () => {
+      if (!Number.isInteger(qty) || qty < 1 || qty > 50) return { error: "數量錯誤" };
 
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: "請先登入" };
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return { error: "請先登入" };
+      identifyUser(user);
 
-  // Cross-check slot ↔ menu_item ↔ date (anti-tampering)
-  const { data: slot } = await supabase
-    .from("daily_slots")
-    .select("id, menu_item_id, date")
-    .eq("id", dailySlotId)
-    .single();
-  if (!slot) return { error: "找不到此時段" };
-  if (slot.menu_item_id !== menuItemId || slot.date !== date) {
-    return { error: "時段與餐點不符" };
-  }
-
-  // Fetch authoritative price + verify vendor ownership
-  const { data: menuItem } = await supabase
-    .from("menu_items")
-    .select("id, price, is_available, vendor_id")
-    .eq("id", menuItemId)
-    .single();
-  if (!menuItem || !menuItem.is_available) return { error: "餐點目前未供應" };
-  if (menuItem.vendor_id !== vendorId) return { error: "餐點與商家不符" };
-
-  // Validate options belong to this menu_item, fetch authoritative price_delta + name
-  type ValidatedOption = { id: string; name: string; price_delta: number };
-  let validatedOptions: ValidatedOption[] = [];
-  const uniqueOptionIds = [...new Set(optionIds)];
-  if (uniqueOptionIds.length > 0) {
-    const { data: optionRows } = await supabase
-      .from("item_options")
-      .select("id, name, price_delta, item_option_groups!inner(menu_item_id)")
-      .in("id", uniqueOptionIds);
-    if (!optionRows || optionRows.length !== uniqueOptionIds.length) {
-      return { error: "選項無效" };
-    }
-    for (const r of optionRows) {
-      const group = r.item_option_groups as { menu_item_id: string } | null;
-      if (group?.menu_item_id !== menuItemId) {
-        return { error: "選項不屬於此餐點" };
+      // Cross-check slot ↔ menu_item ↔ date (anti-tampering)
+      const { data: slot } = await supabase
+        .from("daily_slots")
+        .select("id, menu_item_id, date")
+        .eq("id", dailySlotId)
+        .single();
+      if (!slot) return { error: "找不到此時段" };
+      if (slot.menu_item_id !== menuItemId || slot.date !== date) {
+        return { error: "時段與餐點不符" };
       }
-    }
-    validatedOptions = optionRows.map((r) => ({
-      id: r.id,
-      name: r.name,
-      price_delta: r.price_delta,
-    }));
-  }
 
-  const unitPrice =
-    Number(menuItem.price) +
-    validatedOptions.reduce((sum, o) => sum + o.price_delta, 0);
+      // Fetch authoritative price + verify vendor ownership
+      const { data: menuItem } = await supabase
+        .from("menu_items")
+        .select("id, price, is_available, vendor_id")
+        .eq("id", menuItemId)
+        .single();
+      if (!menuItem || !menuItem.is_available) return { error: "餐點目前未供應" };
+      if (menuItem.vendor_id !== vendorId) return { error: "餐點與商家不符" };
 
-  // Find or create pending order
-  let orderId: string;
-  const { data: existing } = await supabase
-    .from("orders")
-    .select("id")
-    .eq("user_id", user.id)
-    .eq("status", "pending")
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+      // Validate options belong to this menu_item, fetch authoritative price_delta + name
+      type ValidatedOption = { id: string; name: string; price_delta: number };
+      let validatedOptions: ValidatedOption[] = [];
+      const uniqueOptionIds = [...new Set(optionIds)];
+      if (uniqueOptionIds.length > 0) {
+        const { data: optionRows } = await supabase
+          .from("item_options")
+          .select("id, name, price_delta, item_option_groups!inner(menu_item_id)")
+          .in("id", uniqueOptionIds);
+        if (!optionRows || optionRows.length !== uniqueOptionIds.length) {
+          return { error: "選項無效" };
+        }
+        for (const r of optionRows) {
+          const group = r.item_option_groups as { menu_item_id: string } | null;
+          if (group?.menu_item_id !== menuItemId) {
+            return { error: "選項不屬於此餐點" };
+          }
+        }
+        validatedOptions = optionRows.map((r) => ({
+          id: r.id,
+          name: r.name,
+          price_delta: r.price_delta,
+        }));
+      }
 
-  if (existing) {
-    orderId = existing.id;
-  } else {
-    const { data: newOrder, error } = await supabase
-      .from("orders")
-      .insert({ user_id: user.id })
-      .select("id")
-      .single();
-    if (error || !newOrder) return { error: "建立訂單失敗" };
-    orderId = newOrder.id;
-  }
+      const unitPrice =
+        Number(menuItem.price) +
+        validatedOptions.reduce((sum, o) => sum + o.price_delta, 0);
 
-  const { data: orderItem, error } = await supabase
-    .from("order_items")
-    .insert({
-      order_id: orderId,
-      menu_item_id: menuItemId,
-      daily_slot_id: dailySlotId,
-      date,
-      qty,
-      unit_price: unitPrice,
-    })
-    .select("id")
-    .single();
+      // Find or create pending order
+      let orderId: string;
+      const { data: existing } = await supabase
+        .from("orders")
+        .select("id")
+        .eq("user_id", user.id)
+        .eq("status", "pending")
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
 
-  if (error) {
-    if (error.code === "23514") return { error: "此日期已售完" };
-    return { error: "加入失敗，請稍後再試" };
-  }
+      if (existing) {
+        orderId = existing.id;
+      } else {
+        const { data: newOrder, error } = await supabase
+          .from("orders")
+          .insert({ user_id: user.id })
+          .select("id")
+          .single();
+        if (error || !newOrder) {
+          captureActionError(error, {
+            action: "addToOrder",
+            tags: { step: "create_order", vendor_id: vendorId },
+            extra: { menuItemId, date },
+          });
+          return { error: "建立訂單失敗" };
+        }
+        orderId = newOrder.id;
+      }
 
-  if (validatedOptions.length > 0) {
-    await supabase.from("order_item_options").insert(
-      validatedOptions.map((o) => ({
-        order_item_id: orderItem.id,
-        option_id: o.id,
-        name: o.name,
-        price_delta: o.price_delta,
-      }))
-    );
-  }
+      const { data: orderItem, error } = await supabase
+        .from("order_items")
+        .insert({
+          order_id: orderId,
+          menu_item_id: menuItemId,
+          daily_slot_id: dailySlotId,
+          date,
+          qty,
+          unit_price: unitPrice,
+        })
+        .select("id")
+        .single();
 
-  revalidatePath(`/menu/${vendorId}`);
-  revalidatePath("/cart");
-  return { success: true };
+      if (error) {
+        // 23514 = the daily-quota CHECK rejected the reservation (sold out). This
+        // is an expected business outcome (the §5.4 "slot.exhausted" signal), not
+        // a bug — leave a breadcrumb for context but don't raise a Sentry issue.
+        if (error.code === "23514") {
+          Sentry.addBreadcrumb({
+            category: "order",
+            level: "info",
+            message: "slot exhausted (daily quota CHECK)",
+            data: { menuItemId, dailySlotId, date, vendor_id: vendorId },
+          });
+          return { error: "此日期已售完" };
+        }
+        captureActionError(error, {
+          action: "addToOrder",
+          tags: { step: "insert_order_item", vendor_id: vendorId, menu_item_id: menuItemId },
+          extra: { dailySlotId, date, qty },
+        });
+        return { error: "加入失敗，請稍後再試" };
+      }
+
+      if (validatedOptions.length > 0) {
+        await supabase.from("order_item_options").insert(
+          validatedOptions.map((o) => ({
+            order_item_id: orderItem.id,
+            option_id: o.id,
+            name: o.name,
+            price_delta: o.price_delta,
+          }))
+        );
+      }
+
+      revalidatePath(`/menu/${vendorId}`);
+      revalidatePath("/cart");
+      return { success: true };
+    },
+  );
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -12,7 +12,11 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
 
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    Sentry.replayIntegration(),
+    // App-wide "Report a Bug" widget; feedback is attached to the Sentry event
+    Sentry.feedbackIntegration({ colorScheme: "system" }),
+  ],
 });
 
 // Captures App Router navigation transitions as spans

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { identifyUser } from "@/lib/observability";
 
 type Role = "admin" | "vendor" | "user";
 
@@ -15,5 +16,6 @@ export async function requireRole(role: Role) {
 
   if (!profile?.role?.includes(role)) throw new Error("權限不足");
 
+  identifyUser(user, profile.role);
   return { user, supabase };
 }

--- a/lib/observability.ts
+++ b/lib/observability.ts
@@ -1,0 +1,51 @@
+import * as Sentry from "@sentry/nextjs";
+
+type AuthedUser = { id: string; email?: string | null };
+
+/**
+ * Attach the signed-in employee's identity + role/area to the Sentry scope so
+ * events carry "who was affected" instead of an anonymous IP. Powers the
+ * affected-user count and per-role triage the autonomous metrics agent reads
+ * (design doc §5.4).
+ */
+export function identifyUser(
+  user: AuthedUser,
+  roles?: readonly string[] | null,
+  areaId?: string | null,
+) {
+  Sentry.setUser({ id: user.id, email: user.email ?? undefined });
+  if (roles && roles.length > 0) Sentry.setTag("user.roles", roles.join(","));
+  if (areaId) Sentry.setTag("user.area", areaId);
+}
+
+/**
+ * Report a failure that the caller handles by returning a graceful `{ error }`.
+ * Without this the error never reaches Sentry. Wraps non-Error causes (e.g. a
+ * Supabase PostgrestError) in an Error so the event keeps a usable message, and
+ * lifts the Postgres error code into a `pg_code` tag for triage.
+ */
+export function captureActionError(
+  cause: unknown,
+  ctx: {
+    action: string;
+    tags?: Record<string, string | undefined>;
+    extra?: Record<string, unknown>;
+  },
+) {
+  const pgCode =
+    typeof cause === "object" && cause !== null && "code" in cause
+      ? String((cause as { code: unknown }).code)
+      : undefined;
+  const message =
+    cause instanceof Error
+      ? cause.message
+      : typeof cause === "object" && cause !== null && "message" in cause
+        ? String((cause as { message: unknown }).message)
+        : `action ${ctx.action} failed`;
+  const error = cause instanceof Error ? cause : new Error(message);
+
+  Sentry.captureException(error, {
+    tags: { action: ctx.action, ...(pgCode ? { pg_code: pgCode } : {}), ...ctx.tags },
+    extra: ctx.extra,
+  });
+}

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -1,4 +1,6 @@
+import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/server";
+import { captureActionError } from "@/lib/observability";
 
 export type RecommendedItem = {
   id: string;
@@ -38,13 +40,25 @@ export async function getHomeItems(
 ): Promise<HomeItem[]> {
   const supabase = await createClient();
 
-  const { data, error } = await supabase.rpc("rank_menu_items_for_home", {
-    p_area_id: areaId ?? undefined,
-    p_limit: limit,
-    p_context_vec: (contextVec ?? undefined) as unknown as string,
-  });
+  const { data, error } = await Sentry.startSpan(
+    { name: "recommend.rank", op: "db.rpc", attributes: { rpc: "rank_menu_items_for_home" } },
+    () =>
+      supabase.rpc("rank_menu_items_for_home", {
+        p_area_id: areaId ?? undefined,
+        p_limit: limit,
+        p_context_vec: (contextVec ?? undefined) as unknown as string,
+      }),
+  );
 
-  if (error || !data) return [];
+  if (error || !data) {
+    if (error)
+      captureActionError(error, {
+        action: "getHomeItems",
+        tags: { rpc: "rank_menu_items_for_home" },
+        extra: { areaId, limit },
+      });
+    return [];
+  }
 
   return data.map((row) => ({
     id: row.id,

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -2,6 +2,7 @@
 import type { SearchFilters } from "@/lib/filters";
 import type { HomeItem } from "@/lib/recommendation";
 import { createClient } from "@/lib/supabase/server";
+import * as Sentry from "@sentry/nextjs";
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
 
@@ -20,9 +21,13 @@ export async function searchHomeItems(
 
   let embedding: number[] | null = null;
   try {
-    const { data: embedRes, error: embedErr } = await supabase.functions.invoke<{
-      embedding: number[];
-    }>("embed-query", { body: { query: trimmed } });
+    const { data: embedRes, error: embedErr } = await Sentry.startSpan(
+      { name: "search.embed", op: "gen_ai.embeddings" },
+      () =>
+        supabase.functions.invoke<{ embedding: number[] }>("embed-query", {
+          body: { query: trimmed },
+        }),
+    );
     if (!embedErr) embedding = embedRes?.embedding ?? null;
   } catch (e) {
     console.error("embed-query failed; degrading to keyword-only:", e);
@@ -31,20 +36,28 @@ export async function searchHomeItems(
   const hasExplicitSort = filters?.sort && filters.sort !== "recommended";
   const fetchLimit = hasExplicitSort ? limit : Math.max(limit, RERANK_POOL);
 
-  const { data, error } = await supabase.rpc("hybrid_search", {
-    p_query: trimmed,
-    p_query_embedding: embedding as unknown as string,
-    p_area_id: areaId ?? undefined,
-    p_limit: fetchLimit,
-    p_open: filters?.open ?? undefined,
-    p_price_min: filters?.priceMin ?? undefined,
-    p_price_max: filters?.priceMax ?? undefined,
-    p_cal_min: filters?.calMin ?? undefined,
-    p_cal_max: filters?.calMax ?? undefined,
-    p_tags: filters?.tags ?? undefined,
-    p_sort: hasExplicitSort ? filters!.sort : undefined,
-    p_dates: filters?.dates ?? undefined,
-  });
+  const { data, error } = await Sentry.startSpan(
+    {
+      name: "search.hybrid",
+      op: "db.rpc",
+      attributes: { rpc: "hybrid_search", embedded: embedding !== null },
+    },
+    () =>
+      supabase.rpc("hybrid_search", {
+        p_query: trimmed,
+        p_query_embedding: embedding as unknown as string,
+        p_area_id: areaId ?? undefined,
+        p_limit: fetchLimit,
+        p_open: filters?.open ?? undefined,
+        p_price_min: filters?.priceMin ?? undefined,
+        p_price_max: filters?.priceMax ?? undefined,
+        p_cal_min: filters?.calMin ?? undefined,
+        p_cal_max: filters?.calMax ?? undefined,
+        p_tags: filters?.tags ?? undefined,
+        p_sort: hasExplicitSort ? filters!.sort : undefined,
+        p_dates: filters?.dates ?? undefined,
+      }),
+  );
   if (error || !data) return [];
 
   const items: HomeItem[] = data.map((row) => ({
@@ -90,9 +103,18 @@ async function rerankItems(
       sodium: i.sodium,
     }));
 
-    const { data, error } = await supabase.functions.invoke<{
-      ranking: Array<{ id: string; score: number }>;
-    }>("rerank-search", { body: { query, candidates } });
+    const { data, error } = await Sentry.startSpan(
+      {
+        name: "search.rerank",
+        op: "gen_ai.rerank",
+        attributes: { candidates: candidates.length },
+      },
+      () =>
+        supabase.functions.invoke<{ ranking: Array<{ id: string; score: number }> }>(
+          "rerank-search",
+          { body: { query, candidates } },
+        ),
+    );
 
     if (error || !data?.ranking?.length) return null;
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -32,7 +32,7 @@ export async function proxy(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  const publicPaths = ["/login", "/auth/callback"];
+  const publicPaths = ["/login", "/auth/callback", "/api/sentry-alert-webhook"];
   if (!user && !publicPaths.some((p) => pathname.startsWith(p))) {
     return NextResponse.redirect(new URL("/login", request.url));
   }


### PR DESCRIPTION
## Summary
Baseline Sentry only caught **unhandled** crashes. This instruments the app's real observability surface, mapped to the design doc:

- **A — user identity** (`lib/observability.ts` `identifyUser`): attaches signed-in employee `id / roles / area` to the Sentry scope from `requireRole()` + order/cart/pickup paths. Affected-user counts (§5.4) now name real people, not an IP.
- **B — business errors** (`captureActionError`): the swallowed `{ error }` returns Sentry never saw — order create/insert, cart confirm/cancel/remove, QR pickup, recommendation rank — now reported with `action / step / pg_code` tags. Sold-out (daily-quota CHECK `23514`) → breadcrumb, not an issue. (NFR6 99% 錯誤可追蹤)
- **C — performance spans**: `addToOrder` (`withServerActionInstrumentation`), recommendation `rank_menu_items_for_home`, and the search `embed / hybrid / rerank` pipeline. (NFR3 P99 latency)
- **D — feedback + alert webhook**: app-wide `feedbackIntegration`; `/api/sentry-alert-webhook` (HMAC-verified, proxy-allowlisted) as the receiving end of the §5.4 alert-driven trigger.

## Manual follow-up (Sentry dashboard, not code)
- Create a Sentry **alert rule / internal integration webhook** → `https://nycueats.winlab.tw/api/sentry-alert-webhook`, and set `SENTRY_WEBHOOK_SECRET` (Vercel env) to the integration's client secret.

## Test plan
- [x] `bun run build` (Turbopack + tsc)
- [x] `bun run lint`
- [x] `bun run test:unit` — 163 passed
- [ ] CI green (lint / unit / e2e / build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)