### PR TITLE
refactor: remove unused RecommendedItem and ItemWithReason types

### DIFF
--- a/lib/reasons.ts
+++ b/lib/reasons.ts
@@ -24,8 +24,6 @@ export async function fetchReasonsForItems(
   return map;
 }
 
-export type ItemWithReason = HomeItem & { reason: string | null };
-
 export function attachReasons<T extends HomeItem>(
   items: T[],
   reasons: Map<string, string>,

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -2,18 +2,6 @@ import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/server";
 import { captureActionError } from "@/lib/observability";
 
-export type RecommendedItem = {
-  id: string;
-  name: string;
-  price: number;
-  description: string | null;
-  tags: string[];
-  calories: number | null;
-  protein: number | null;
-  vendor_id: string;
-  vendor_name: string;
-};
-
 export type HomeItem = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- Delete `RecommendedItem` (lib/recommendation.ts) — zero references; superseded by `HomeItem`.
- Delete `ItemWithReason` (lib/reasons.ts) — zero references; `attachReasons` returns an inline `T & { reason }` intersection instead, so the named alias was orphaned.

Found via a deadcode audit (7 finders + adversarial per-finding verification). Both confirmed unreferenced across code, tests, SQL, and config.

## Test plan
- [x] `bunx tsc --noEmit` — no new type errors from the change
- [x] `bun run test:unit -- lib/recommendation.test.ts lib/reasons.test.ts` — 8 passed
- [ ] CI green (lint + unit + e2e + build)