### PR TITLE
docs: mark 2026-05-26 reviews and superpowers docs as archival

### DIFF
--- a/docs/reviews/2026-05-26-architecture.md
+++ b/docs/reviews/2026-05-26-architecture.md
@@ -1,5 +1,7 @@
 # Architecture Review — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 [METHOD: source-first]
 
 ## Summary

--- a/docs/reviews/2026-05-26-coding-style.md
+++ b/docs/reviews/2026-05-26-coding-style.md
@@ -1,5 +1,7 @@
 # Coding Style Review — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 ## Summary
 
 整體 style 一致性高 — 零 `any` 濫用、零 `for simplicity` antipattern、`'use client'` 使用克制、`useEffect` 只剩兩處合理用例（IntersectionObserver、QR code 生成）。Server Component 優先原則執行得很乾淨。主要扣分在三類重複：(1) shadcn 的兩個 chart 元件 90% 重複只差欄位，(2) 多個 vendor server action 重複 `auth.getUser() → 查 vendors by owner_id` 而沒走 `requireVendor()` helper，(3) 13 個 `as { ... }` 手動 cast supabase join 結果指向同一個型別問題 root cause。另有兩個檔案稍微超過 200 行、一個 dead-code component (`AddMenuItemButton`)、type 引用方式 (`Tables<>` vs `Database["public"]...`) 不統一。

--- a/docs/reviews/2026-05-26-documentation.md
+++ b/docs/reviews/2026-05-26-documentation.md
@@ -1,5 +1,7 @@
 # Documentation Review — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 ## Summary
 
 審 11 個 root + rules + docs 檔。Documentation drift 集中在三個方向：(1) README 的 「Implemented Features」漏掉 vendor revenue dashboard；(2) `.claude/rules/uiux.md` 跟 `DESIGN.md` 對圓角 token 直接打架，但沒有任何交叉引用；(3) `EXAMPLES.md` / `test-accounts.md` / README 對「測試帳號密碼」三個地方說三套。Main session 已知三 drift（`(user)/(vendor)/(admin)` route groups、CI e2e、slot-limiting DDL）不重複報。

--- a/docs/reviews/2026-05-26-security.md
+++ b/docs/reviews/2026-05-26-security.md
@@ -1,5 +1,7 @@
 # Security Review — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 ## Summary
 RLS coverage 完整、所有 server actions 都過 auth/role 檢查、無 `service_role` 洩漏到 client。但有兩個 **可直接拿來提權 / 偽造金額** 的漏洞，加上一組過寬的 storage policy 使任何登入者能改別人的圖。整體 posture 中等偏弱，主要問題是「policy 寫了但 WITH CHECK 漏」這類細節型 RLS 缺口，必須在 prod 前收。
 

--- a/docs/reviews/2026-05-26-summary.md
+++ b/docs/reviews/2026-05-26-summary.md
@@ -1,5 +1,7 @@
 # Multi-Aspect Review Synthesis — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 > 6 個 reviewer（security / uiux / coding-style / architecture / documentation / testing）獨立 review TSMC Eats，本文做 cross-cutting 整合。各原始報告在同目錄 `2026-05-26-<aspect>.md`。
 
 ## TL;DR

--- a/docs/reviews/2026-05-26-testing.md
+++ b/docs/reviews/2026-05-26-testing.md
@@ -1,5 +1,7 @@
 # Testing Review — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 [METHOD: source-first]
 
 ## Summary

--- a/docs/reviews/2026-05-26-uiux.md
+++ b/docs/reviews/2026-05-26-uiux.md
@@ -1,5 +1,7 @@
 # UI/UX Review — 2026-05-26
 
+> **Status:** Archived snapshot (2026-05-26). Point-in-time review — many items have been addressed since (see PRs #129–#132 and `git log`); some may still be open. Verify against current code before acting. **Not a live TODO list.**
+
 ## Summary
 
 DESIGN.md 的 Tokens 已落地到 `app/globals.css`（surface / brand / radius / shadow / type scale 都有 CSS variable）`[SOURCE: app/globals.css:50-101,138-167]`，但 component / page 端的對齊度只到約 20% — 144 處仍用 legacy `text-(xs|sm|...)` scale、37 處用 token；圓角頻繁出現禁用值 `rounded-2xl / rounded-full / rounded-lg`，照片優先卡片被「圖片暫時隱藏」整段註解掉 `[SOURCE: components/menu-item-card.tsx:41-49]`。Photography-first 規則目前等於沒實作；多處 admin / orders 直接用 raw Tailwind palette（`bg-blue-50`、`text-yellow-600`）無對應 token 與 dark 樣式。

--- a/docs/superpowers/plans/2026-03-28-admin-dashboard.md
+++ b/docs/superpowers/plans/2026-03-28-admin-dashboard.md
@@ -1,5 +1,7 @@
 # 管理員後台 Implementation Plan
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 建立福委會管理後台 — 商家審核（申請制）、營運數據 Dashboard、多廠區商家服務範圍管理。

--- a/docs/superpowers/plans/2026-03-28-order-flow.md
+++ b/docs/superpowers/plans/2026-03-28-order-flow.md
@@ -1,5 +1,7 @@
 # 訂單流程補完 Implementation Plan
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 補完訂單生命週期 — 結帳確認、取消、訂單紀錄頁（infinite scroll）、領餐 QR code、商家批次/逐筆管理。

--- a/docs/superpowers/plans/2026-03-28-testing-infra.md
+++ b/docs/superpowers/plans/2026-03-28-testing-infra.md
@@ -1,5 +1,7 @@
 # 測試基礎設施 + CI Implementation Plan
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 建立 Playwright e2e 測試 + GitHub Actions CI，讓每個 PR 自動跑 lint + build + test。

--- a/docs/superpowers/plans/2026-04-15-bulk-slot-creation.md
+++ b/docs/superpowers/plans/2026-04-15-bulk-slot-creation.md
@@ -1,5 +1,7 @@
 # Bulk Slot Creation Implementation Plan
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a smart banner and bulk slot dialog to `/vendor/menu` so vendors can create daily slots for all menu items across two calendar weeks in one action.

--- a/docs/superpowers/plans/2026-05-10-vendor-revenue-stats.md
+++ b/docs/superpowers/plans/2026-05-10-vendor-revenue-stats.md
@@ -1,5 +1,7 @@
 # Vendor Revenue Statistics Implementation Plan
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a vendor-only revenue statistics page that shows monthly revenue, order count, sold quantity, daily revenue trend, and top menu items.

--- a/docs/superpowers/plans/2026-05-26-search-filter-panel.md
+++ b/docs/superpowers/plans/2026-05-26-search-filter-panel.md
@@ -1,5 +1,7 @@
 # Search Filter Panel Implementation Plan
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a filter panel popover next to the search bar on user pages — five filter dimensions (open now, date, price, calories, tags) plus sort — stored as URL params and applied at DB level via an extended `hybrid_search` Postgres function.

--- a/docs/superpowers/specs/2026-03-23-nycueats-mvp-design.md
+++ b/docs/superpowers/specs/2026-03-23-nycueats-mvp-design.md
@@ -1,5 +1,7 @@
 # TSMC Eats MVP Design
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 Date: 2026-03-23
 
 ## Overview

--- a/docs/superpowers/specs/2026-03-28-admin-dashboard-design.md
+++ b/docs/superpowers/specs/2026-03-28-admin-dashboard-design.md
@@ -1,5 +1,7 @@
 # 管理員後台 — 設計文件
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > Issue #8 + #9 | Milestone v0.4.0
 
 ## 目標

--- a/docs/superpowers/specs/2026-03-28-order-flow-design.md
+++ b/docs/superpowers/specs/2026-03-28-order-flow-design.md
@@ -1,5 +1,7 @@
 # 訂單流程補完 — 設計文件
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > Issue #2 | Milestone v0.2.0
 
 ## 目標

--- a/docs/superpowers/specs/2026-03-28-testing-infra-design.md
+++ b/docs/superpowers/specs/2026-03-28-testing-infra-design.md
@@ -1,5 +1,7 @@
 # 測試基礎設施 + CI — 設計文件
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 > Issue #7 | Milestone v1.0.0
 
 ## 目標

--- a/docs/superpowers/specs/2026-04-15-bulk-slot-creation-design.md
+++ b/docs/superpowers/specs/2026-04-15-bulk-slot-creation-design.md
@@ -1,5 +1,7 @@
 # 批次名額建立（Bulk Slot Creation）設計文件
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 ## 問題
 
 商家的 `daily_slots` 只在手動開啟編輯 Dialog 並 blur 輸入框時才會寫入 DB。一旦已建立的 slot 日期全部過期，使用者就無法訂餐，直到商家重新手動設定。這造成每週都需要重複操作，容易遺漏。

--- a/docs/superpowers/specs/2026-05-10-vendor-revenue-stats-design.md
+++ b/docs/superpowers/specs/2026-05-10-vendor-revenue-stats-design.md
@@ -1,5 +1,7 @@
 # 商家營業額統計 — 設計文件
 
+> **Status:** Shipped — archived design doc. The feature described here has since been implemented; kept as a historical record, not a current spec. See the codebase and `README.md` for as-built behavior.
+
 ## Goal
 
 在商家後台新增「營業額統計」頁面，讓商家查看自己店家的月營收與銷售表現。這個頁面概念上接近管理員的營運總覽，但資料範圍只限目前登入商家，不顯示其他商家的營收。

--- a/docs/superpowers/specs/2026-05-26-search-filter-panel-design.md
+++ b/docs/superpowers/specs/2026-05-26-search-filter-panel-design.md
@@ -1,7 +1,7 @@
 # Search Filter Panel — Design Spec
 
 **Date:** 2026-05-26
-**Status:** Approved for implementation
+**Status:** Shipped — archived design doc (implemented; see `app/search/`, `components/filter-panel.tsx`)
 
 ---
 


### PR DESCRIPTION
## Summary
Doc-only. Adds a `> **Status:**` banner to point-in-time artifacts so they aren't read as live work:

- **docs/reviews/2026-05-26-*.md** (7) — "Archived snapshot; many items resolved since #129–#132; verify before acting; not a live TODO list."
- **docs/superpowers/plans/*.md** (6) + **specs/*.md** (7) — "Shipped — archived design doc." The search-filter spec's `Status: Approved for implementation` is updated to `Shipped`.

Bodies are left untouched (historical record). 20 files, header-only changes.

## Test plan
- [x] Doc-only; `git diff --stat` is 20 `.md` files, each +2 lines
- [ ] CI green