### PR TITLE
feat(ui): move Sentry feedback to a header Bug button

### DIFF
--- a/components/feedback-button.tsx
+++ b/components/feedback-button.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import * as Sentry from "@sentry/nextjs";
+import { Bug } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+export function FeedbackButton() {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  // Attach the Sentry feedback form to this button on the client. Reading
+  // getFeedback() inside the effect keeps it client-only (no hydration mismatch);
+  // attachTo returns an unsubscribe handler used for cleanup.
+  useEffect(() => {
+    const el = ref.current;
+    const feedback = Sentry.getFeedback();
+    if (el && feedback) {
+      return feedback.attachTo(el, { formTitle: "回報問題" });
+    }
+  }, []);
+
+  return (
+    <Button ref={ref} variant="outline" aria-label="回報問題">
+      <Bug className="size-4" />
+    </Button>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import { AreaSelect } from "./area-select";
+import { FeedbackButton } from "./feedback-button";
 import { SearchForm } from "./search-form";
 import { ThemeToggle } from "./theme-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -78,6 +79,7 @@ export async function Header() {
             <Button variant="outline" size="sm">商家後台</Button>
           </Link>
         )}
+        <FeedbackButton />
         <ThemeToggle />
         {navigation.showOrders && (
           <Link href="/orders">

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -14,8 +14,10 @@ Sentry.init({
 
   integrations: [
     Sentry.replayIntegration(),
-    // App-wide "Report a Bug" widget; feedback is attached to the Sentry event
-    Sentry.feedbackIntegration({ colorScheme: "system" }),
+    // Feedback form wired to a custom Bug button in the header (see
+    // components/feedback-button.tsx); autoInject disables the default
+    // floating bottom-right widget.
+    Sentry.feedbackIntegration({ colorScheme: "system", autoInject: false }),
   ],
 });
 


### PR DESCRIPTION
## Summary
The bottom-right "Report a Bug" widget was Sentry's `feedbackIntegration()` default auto-injected button (not a framework default — added in the Sentry instrumentation PR). Replace it with a header button:

- `instrumentation-client.ts` — `feedbackIntegration({ colorScheme: "system", autoInject: false })` so Sentry no longer injects the floating widget.
- `components/feedback-button.tsx` (new, `"use client"`) — a `Bug` icon button that attaches the feedback form via `Sentry.getFeedback()?.attachTo(ref)` (client-only in `useEffect`, returns the unsubscribe handler for cleanup).
- `components/header.tsx` — render `<FeedbackButton />` in the utility row before `<ThemeToggle />`, so it's visible on every page including `/login`.

Feedback form text is still Sentry's default English (only `formTitle` set to 回報問題) — full localization can be a follow-up.

## Test plan
- [x] `bunx tsc --noEmit` + `eslint` clean
- [x] `bun run build` compiles; local `next start` serves `/login` with the Bug button in the header (`aria-label="回報問題"`, order `[Bug] [ThemeToggle]`)
- [ ] CI green