### PR TITLE
feat(ui): localize the Sentry feedback form to zh-TW

### DIFF
--- a/components/feedback-button.tsx
+++ b/components/feedback-button.tsx
@@ -15,7 +15,7 @@ export function FeedbackButton() {
     const el = ref.current;
     const feedback = Sentry.getFeedback();
     if (el && feedback) {
-      return feedback.attachTo(el, { formTitle: "回報問題" });
+      return feedback.attachTo(el);
     }
   }, []);
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -16,8 +16,25 @@ Sentry.init({
     Sentry.replayIntegration(),
     // Feedback form wired to a custom Bug button in the header (see
     // components/feedback-button.tsx); autoInject disables the default
-    // floating bottom-right widget.
-    Sentry.feedbackIntegration({ colorScheme: "system", autoInject: false }),
+    // floating bottom-right widget. Labels localized to zh-TW.
+    Sentry.feedbackIntegration({
+      colorScheme: "system",
+      autoInject: false,
+      showBranding: false,
+      formTitle: "回報問題",
+      submitButtonLabel: "送出",
+      cancelButtonLabel: "取消",
+      nameLabel: "姓名",
+      namePlaceholder: "你的名字",
+      emailLabel: "Email",
+      emailPlaceholder: "你的 email",
+      messageLabel: "問題描述",
+      messagePlaceholder: "請描述你遇到的問題，越具體越好…",
+      isRequiredLabel: "（必填）",
+      addScreenshotButtonLabel: "加上截圖",
+      removeScreenshotButtonLabel: "移除截圖",
+      successMessageText: "感謝你的回報！",
+    }),
   ],
 });
 


### PR DESCRIPTION
## Summary
Follow-up to #138 — the feedback form text was still Sentry's default English. Localize every label on `feedbackIntegration()` to Traditional Chinese: 回報問題 / 姓名 / Email / 問題描述 + placeholders, 送出 / 取消, 加上截圖 / 移除截圖, （必填）, 感謝你的回報！. Also `showBranding: false`. The header Bug button's `attachTo()` no longer needs per-call options (title now lives on the integration).

Option names verified against Sentry docs and the `feedbackIntegration` TypeScript types (`tsc --noEmit` accepts all 15).

## Test plan
- [x] `bunx tsc --noEmit` (validates every option name) + `eslint` clean
- [x] `bun run build` compiles
- [ ] CI green