### PR TITLE
test: improve backend coverage

### DIFF
--- a/app/admin/actions.test.ts
+++ b/app/admin/actions.test.ts
@@ -4,7 +4,7 @@ const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
 
 vi.mock("@/lib/supabase/server", () => ({ createClient: createClientMock }));
 
-import { getDashboardStats, getTopMenuItems, getTopVendors } from "@/app/admin/actions";
+import { getDashboardStats, getOrderTrend, getTopMenuItems, getTopVendors } from "@/app/admin/actions";
 import { createSupabaseMock, roleProfile } from "@/test/supabase-mock";
 
 describe("getDashboardStats", () => {
@@ -73,6 +73,41 @@ describe("getDashboardStats", () => {
       completionRate: 0,
       cancelRate: 0,
     });
+  });
+});
+
+describe("getOrderTrend", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T12:00:00.000Z"));
+  });
+
+  it("builds a daily order count series for the requested window", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "admin1" },
+      expectations: [
+        roleProfile("admin"),
+        {
+          table: "orders",
+          result: {
+            data: [
+              { created_at: "2026-05-25T08:00:00.000Z" },
+              { created_at: "2026-05-25T12:30:00.000Z" },
+              { created_at: "2026-05-27T09:00:00.000Z" },
+              { created_at: "2026-05-20T09:00:00.000Z" },
+            ],
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    await expect(getOrderTrend(3)).resolves.toEqual([
+      { date: "2026-05-25", count: 2 },
+      { date: "2026-05-26", count: 0 },
+      { date: "2026-05-27", count: 1 },
+    ]);
   });
 });
 

--- a/app/api/pickup/route.test.ts
+++ b/app/api/pickup/route.test.ts
@@ -79,6 +79,108 @@ describe("pickup route", () => {
     expect(await res.text()).toBe("此品項不屬於您的商店");
   });
 
+  it("rejects vendors without a store record", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("找不到商家帳號");
+  });
+
+  it("rejects order items that are not confirmed", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: false,
+              order_id: "o1",
+              menu_items: { vendor_id: "v1" },
+              orders: { status: "pending" },
+            },
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("此訂單狀態不允許領餐");
+  });
+
+  it("redirects already-picked-up items without mutating", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: true,
+              order_id: "o1",
+              menu_items: { vendor_id: "v1" },
+              orders: { status: "confirmed" },
+            },
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/vendor/orders?msg=already-picked-up");
+    expect(mutations).toEqual([]);
+  });
+
+  it("returns a server error when marking the item picked up fails", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: false,
+              order_id: "o1",
+              menu_items: { vendor_id: "v1" },
+              orders: { status: "confirmed" },
+            },
+          },
+        },
+        { table: "order_items", result: { data: null, error: { message: "update failed" } } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("核銷失敗，請稍後再試");
+  });
+
   it("marks the item picked up and completes the order when no items remain", async () => {
     const { client, mutations } = createSupabaseMock({
       user: { id: "u1" },
@@ -100,6 +202,74 @@ describe("pickup route", () => {
         { table: "order_items", result: { data: null, error: null } },
         { table: "order_items", result: { data: [] } },
         { table: "orders", result: { data: null, error: null } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/vendor/orders?msg=picked-up");
+    expect(mutations).toEqual([
+      { table: "order_items", op: "update", payload: { picked_up: true } },
+      { table: "orders", op: "update", payload: { status: "completed" } },
+    ]);
+  });
+
+  it("keeps the order open when other items remain unpicked", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: false,
+              order_id: "o1",
+              menu_items: { vendor_id: "v1" },
+              orders: { status: "confirmed" },
+            },
+          },
+        },
+        { table: "order_items", result: { data: null, error: null } },
+        { table: "order_items", result: { data: [{ id: "oi2" }] } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const res = await GET(request("https://example.test/api/pickup?item=oi1"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/vendor/orders?msg=picked-up");
+    expect(mutations).toEqual([
+      { table: "order_items", op: "update", payload: { picked_up: true } },
+    ]);
+  });
+
+  it("still redirects when completing the order fails after pickup", async () => {
+    const { client, mutations } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        { table: "profiles", result: { data: { role: ["vendor"] } } },
+        { table: "vendors", result: { data: { id: "v1" } } },
+        {
+          table: "order_items",
+          result: {
+            data: {
+              id: "oi1",
+              picked_up: false,
+              order_id: "o1",
+              menu_items: { vendor_id: "v1" },
+              orders: { status: "confirmed" },
+            },
+          },
+        },
+        { table: "order_items", result: { data: null, error: null } },
+        { table: "order_items", result: { data: [] } },
+        { table: "orders", result: { data: null, error: { message: "complete failed" } } },
       ],
     });
     createClientMock.mockResolvedValue(client);

--- a/app/api/sentry-alert-webhook/route.test.ts
+++ b/app/api/sentry-alert-webhook/route.test.ts
@@ -1,0 +1,57 @@
+import { createHmac } from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { addBreadcrumbMock } = vi.hoisted(() => ({ addBreadcrumbMock: vi.fn() }));
+
+vi.mock("@sentry/nextjs", () => ({ addBreadcrumb: addBreadcrumbMock }));
+
+import { POST } from "@/app/api/sentry-alert-webhook/route";
+
+function request(body: string, headers: Record<string, string> = {}) {
+  return new Request("https://example.test/api/sentry-alert-webhook", {
+    method: "POST",
+    body,
+    headers,
+  });
+}
+
+describe("sentry alert webhook route", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    addBreadcrumbMock.mockReset();
+  });
+
+  it("rejects requests with an invalid signature when a secret is configured", async () => {
+    vi.stubEnv("SENTRY_WEBHOOK_SECRET", "secret");
+
+    const res = await POST(request("{}", { "sentry-hook-signature": "bad" }) as never);
+
+    await expect(res.text()).resolves.toBe("invalid signature");
+    expect(res.status).toBe(401);
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid json after signature verification", async () => {
+    vi.stubEnv("SENTRY_WEBHOOK_SECRET", "secret");
+    const raw = "{";
+    const signature = createHmac("sha256", "secret").update(raw).digest("hex");
+
+    const res = await POST(request(raw, { "sentry-hook-signature": signature }) as never);
+
+    await expect(res.text()).resolves.toBe("invalid json");
+    expect(res.status).toBe(400);
+  });
+
+  it("acknowledges a valid webhook and records a breadcrumb", async () => {
+    const res = await POST(
+      request(JSON.stringify({ id: "evt-1" }), { "sentry-hook-resource": "issue" }) as never,
+    );
+
+    await expect(res.json()).resolves.toEqual({ received: true, resource: "issue" });
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      category: "sentry.webhook",
+      level: "info",
+      message: "received issue webhook",
+    });
+  });
+});

--- a/app/cart/actions.test.ts
+++ b/app/cart/actions.test.ts
@@ -105,6 +105,47 @@ describe("cart server actions", () => {
     expect(revalidatePathMock).toHaveBeenCalledWith("/orders");
   });
 
+  it("returns an error when confirming a missing order", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [{ singleResult: { data: null } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(confirmOrder("order-1")).resolves.toEqual({ error: "找不到預約單" });
+  });
+
+  it("returns an error when confirming a non-pending order", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [{ singleResult: { data: { id: "order-1", status: "confirmed" } } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(confirmOrder("order-1")).resolves.toEqual({ error: "預約單狀態不符" });
+  });
+
+  it("returns an error when the order status update fails", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [
+          { singleResult: { data: { id: "order-1", status: "pending" } } },
+          { eqResults: [{ error: { message: "db down" } }] },
+        ],
+        order_items: [{ limitResult: { data: [{ id: "item-1" }] } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(confirmOrder("order-1")).resolves.toEqual({ error: "確認失敗" });
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
   it("refuses to confirm an empty pending order", async () => {
     const supabase = createSupabaseMock({
       user: { id: "user-1" },
@@ -138,6 +179,67 @@ describe("cart server actions", () => {
     expect(revalidatePathMock).toHaveBeenCalledWith("/orders");
   });
 
+  it("rejects canceling when the user is not logged in", async () => {
+    const supabase = createSupabaseMock({ user: null, queries: {} });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(cancelOrder("order-1")).resolves.toEqual({ error: "未登入" });
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when canceling a missing order", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [{ singleResult: { data: null } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(cancelOrder("order-1")).resolves.toEqual({ error: "找不到預約單" });
+  });
+
+  it("returns an error when canceling a non-pending order", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [{ singleResult: { data: { id: "order-1", status: "confirmed" } } }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(cancelOrder("order-1")).resolves.toEqual({ error: "預約單狀態不符" });
+  });
+
+  it("returns an error when clearing order items fails", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [{ singleResult: { data: { id: "order-1", status: "pending" } } }],
+        order_items: [{ eqResults: [{ error: { message: "delete failed" } }] }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(cancelOrder("order-1")).resolves.toEqual({ error: "清空失敗" });
+  });
+
+  it("returns an error when canceling the order status update fails", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        orders: [
+          { singleResult: { data: { id: "order-1", status: "pending" } } },
+          { eqResults: [{ error: { message: "update failed" } }] },
+        ],
+        order_items: [{ eqResults: [{ error: null }] }],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(cancelOrder("order-1")).resolves.toEqual({ error: "取消失敗" });
+  });
+
   it("removes an order item owned by the current user", async () => {
     const supabase = createSupabaseMock({
       user: { id: "user-1" },
@@ -156,6 +258,33 @@ describe("cart server actions", () => {
 
     await expect(removeOrderItem("item-1")).resolves.toEqual({ success: true });
     expect(revalidatePathMock).toHaveBeenCalledWith("/cart");
+  });
+
+  it("rejects removing an item when the user is not logged in", async () => {
+    const supabase = createSupabaseMock({ user: null, queries: {} });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(removeOrderItem("item-1")).resolves.toEqual({ error: "未登入" });
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when deleting an owned item fails", async () => {
+    const supabase = createSupabaseMock({
+      user: { id: "user-1" },
+      queries: {
+        order_items: [
+          {
+            singleResult: {
+              data: { id: "item-1", orders: { user_id: "user-1" } },
+            },
+          },
+          { eqResults: [{ error: { message: "delete failed" } }] },
+        ],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(removeOrderItem("item-1")).resolves.toEqual({ error: "取消失敗" });
   });
 
   it("blocks removing an item owned by another user", async () => {

--- a/app/login/actions.test.ts
+++ b/app/login/actions.test.ts
@@ -47,6 +47,41 @@ describe("login actions", () => {
     expect(redirectMock).toHaveBeenCalledWith("/vendor");
   });
 
+  it("redirects email sign in to home when Supabase returns no user", async () => {
+    const { client } = createSupabaseMock({
+      user: null,
+      expectations: [],
+    });
+    (client.auth as typeof client.auth & {
+      signInWithPassword: ReturnType<typeof vi.fn>;
+    }).signInWithPassword = vi.fn(async () => ({ error: null }));
+    createClientMock.mockResolvedValue(client);
+    redirectMock.mockImplementationOnce((url: string) => {
+      throw new Error(`redirect:${url}`);
+    });
+
+    await expect(signInWithEmail("u@example.test", "pw")).rejects.toThrow("redirect:/");
+
+    expect(redirectMock).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects Google OAuth failures back to login", async () => {
+    const signInWithOAuth = vi.fn(async () => ({
+      data: { url: null },
+      error: { message: "oauth failed" },
+    }));
+    createClientMock.mockResolvedValue({ auth: { signInWithOAuth } });
+    headersMock.mockResolvedValue({ get: vi.fn(() => null) });
+
+    await signInWithGoogle();
+
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: { redirectTo: "/auth/callback" },
+    });
+    expect(redirectMock).toHaveBeenCalledWith("/login?error=auth");
+  });
+
   it("starts Google OAuth with the callback URL from request origin", async () => {
     const signInWithOAuth = vi.fn(async () => ({
       data: { url: "https://accounts.google.test/oauth" },

--- a/app/menu/[id]/actions.test.ts
+++ b/app/menu/[id]/actions.test.ts
@@ -102,6 +102,22 @@ describe("addToOrder", () => {
     expect(result).toEqual({ error: "時段與餐點不符" });
   });
 
+  it("rejects when the daily slot is missing", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: null },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "找不到此時段" });
+  });
+
   it("rejects when the menu_item does not belong to the vendor (anti-tampering)", async () => {
     const { client } = createSupabaseMock({
       user: { id: "u1" },
@@ -122,6 +138,28 @@ describe("addToOrder", () => {
 
     const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
     expect(result).toEqual({ error: "餐點與商家不符" });
+  });
+
+  it("rejects when the menu item is unavailable", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: false, vendor_id: "v1" },
+          },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "餐點目前未供應" });
   });
 
   it("computes unit_price from server-fetched price + option deltas, ignoring any client-side number", async () => {
@@ -208,6 +246,83 @@ describe("addToOrder", () => {
 
     const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, ["o1"]);
     expect(result).toEqual({ error: "選項不屬於此餐點" });
+  });
+
+  it("rejects when not all selected options can be loaded", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "v1" },
+          },
+        },
+        {
+          table: "item_options",
+          result: { data: [] },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, ["o1"]);
+    expect(result).toEqual({ error: "選項無效" });
+  });
+
+  it("returns an error when creating a pending order fails", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "v1" },
+          },
+        },
+        { table: "orders", result: { data: null } },
+        { table: "orders", result: { data: null, error: { message: "insert failed" } } },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "建立訂單失敗" });
+  });
+
+  it("returns a retryable error when inserting the order item fails", async () => {
+    const { client } = createSupabaseMock({
+      user: { id: "u1" },
+      expectations: [
+        {
+          table: "daily_slots",
+          result: { data: { id: "s1", menu_item_id: "m1", date: "2026-05-27" } },
+        },
+        {
+          table: "menu_items",
+          result: {
+            data: { id: "m1", price: 100, is_available: true, vendor_id: "v1" },
+          },
+        },
+        { table: "orders", result: { data: { id: "ord1" } } },
+        {
+          table: "order_items",
+          result: { data: null, error: { code: "XX000", message: "insert failed" } },
+        },
+      ],
+    });
+    createClientMock.mockResolvedValue(client);
+
+    const result = await addToOrder("v1", "m1", "s1", "2026-05-27", 1, []);
+    expect(result).toEqual({ error: "加入失敗，請稍後再試" });
   });
 
   it("translates Postgres CHECK violation (23514) to 此日期已售完", async () => {

--- a/app/vendor/menu/actions.test.ts
+++ b/app/vendor/menu/actions.test.ts
@@ -183,6 +183,26 @@ describe("vendor menu actions", () => {
       expect(revalidatePathMock).toHaveBeenCalledWith("/vendor/menu");
     });
 
+    it("runs the scheduled AI tagging callback after creating an item", async () => {
+      const { client } = createSupabaseMock({
+        user: { id: "u1" },
+        expectations: [
+          ...vendorContext("v1"),
+          { table: "menu_items", result: { data: { id: "m1" }, error: null } },
+        ],
+        invokeResult: { data: { results: [{ id: "m1", status: "ok" }] }, error: null },
+      });
+      createClientMock.mockResolvedValue(client);
+
+      await upsertMenuItem({ name: "雞腿飯", price: 120 });
+      const callback = afterMock.mock.calls[0][0] as () => Promise<void>;
+      await callback();
+
+      expect(client.functions.invoke).toHaveBeenCalledWith("generate-menu-item-tags", {
+        body: { menu_item_ids: ["m1"], force: false },
+      });
+    });
+
     it("updates an existing item scoped to the current vendor", async () => {
       const { client, mutations } = createSupabaseMock({
         user: { id: "u1" },

--- a/lib/context.test.ts
+++ b/lib/context.test.ts
@@ -54,6 +54,60 @@ describe("getCurrentContext", () => {
     });
   });
 
+  it("maps afternoon, evening, and night weather bands", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          current: { temperature_2m: 22, precipitation: 0, time: "2026-05-27T15:30" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          current: { temperature_2m: 12, precipitation: 0, time: "2026-05-27T19:30" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          current: { temperature_2m: 29, precipitation: 0, time: "2026-05-27T23:30" },
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getCurrentContext()).resolves.toMatchObject({
+      hourBand: "afternoon",
+      tempBand: "mild",
+      rainy: false,
+    });
+    await expect(getCurrentContext()).resolves.toMatchObject({
+      hourBand: "evening",
+      tempBand: "cold",
+    });
+    await expect(getCurrentContext()).resolves.toMatchObject({
+      hourBand: "night",
+      tempBand: "hot",
+    });
+  });
+
+  it("returns null when weather data is missing or fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ current: { precipitation: 0 } }),
+      })),
+    );
+    await expect(getCurrentContext()).resolves.toBeNull();
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("network down");
+    }));
+    await expect(getCurrentContext()).resolves.toBeNull();
+  });
+
   it("returns null when weather fetch fails", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })));
 
@@ -79,6 +133,15 @@ describe("getContextEmbedding", () => {
     expect(invoke).not.toHaveBeenCalled();
   });
 
+  it("uses cached array embeddings without parsing", async () => {
+    const { client, invoke } = makeContextClient({ cached: [0.5, 0.6] });
+
+    await expect(
+      getContextEmbedding(client as never, { hourBand: "morning", tempBand: "mild", rainy: false }),
+    ).resolves.toEqual([0.5, 0.6]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
   it("invokes embed-query and caches the result on a cache miss", async () => {
     const { client, invoke, upsert } = makeContextClient({ embedding: [0.3, 0.4] });
 
@@ -99,6 +162,28 @@ describe("getContextEmbedding", () => {
 
     await expect(
       getContextEmbedding(client as never, { hourBand: "night", tempBand: "hot", rainy: true }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the embedding edge function throws", async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null }));
+    const builder = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      maybeSingle,
+      upsert: vi.fn(),
+    };
+    const client = {
+      from: vi.fn(() => builder),
+      functions: {
+        invoke: vi.fn(async () => {
+          throw new Error("edge unavailable");
+        }),
+      },
+    };
+
+    await expect(
+      getContextEmbedding(client as never, { hourBand: "evening", tempBand: "cold", rainy: true }),
     ).resolves.toBeNull();
   });
 });

--- a/lib/filters.test.ts
+++ b/lib/filters.test.ts
@@ -26,6 +26,11 @@ describe("parseFiltersFromParams", () => {
     expect(f).toMatchObject({ priceMin: 60, priceMax: 280 });
   });
 
+  it("parses calorie range", () => {
+    const f = parseFiltersFromParams({ cal_min: "100", cal_max: "500" });
+    expect(f).toMatchObject({ calMin: 100, calMax: 500 });
+  });
+
   it("parses comma-separated tags", () => {
     const f = parseFiltersFromParams({ tags: "spicy,rice" });
     expect(f.tags).toEqual(["spicy", "rice"]);
@@ -56,6 +61,8 @@ describe("filtersToSearchParams", () => {
       sort: "price_asc",
       priceMin: 60,
       priceMax: 280,
+      calMin: 100,
+      calMax: 500,
       tags: ["spicy", "rice"],
       dates: ["2026-05-26"],
     };
@@ -81,6 +88,10 @@ describe("countActiveFilters", () => {
 
   it("price range counts as 1 even when only min is set", () => {
     expect(countActiveFilters({ priceMin: 50 })).toBe(1);
+  });
+
+  it("calorie range counts as 1 even when only max is set", () => {
+    expect(countActiveFilters({ calMax: 500 })).toBe(1);
   });
 
   it("does not count sort=recommended", () => {

--- a/lib/recommendation.test.ts
+++ b/lib/recommendation.test.ts
@@ -112,6 +112,46 @@ describe("getTrendingItems", () => {
     expect(menuItemsBuilder.eq).toHaveBeenCalledWith("vendors.vendor_areas.area_id", "area-1");
   });
 
+  it("returns [] when the menu item lookup returns no rows", async () => {
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(makeThenable({ data: [{ menu_item_id: "m1", qty: 1 }] }))
+      .mockReturnValueOnce(makeThenable({ data: null }));
+    createClientMock.mockResolvedValue({ from });
+
+    await expect(getTrendingItems()).resolves.toEqual([]);
+  });
+
+  it("drops missing menu item rows and fills safe vendor defaults", async () => {
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(makeThenable({
+        data: [
+          { menu_item_id: "missing", qty: 3 },
+          { menu_item_id: "m1", qty: 1 },
+        ],
+      }))
+      .mockReturnValueOnce(makeThenable({
+        data: [
+          {
+            ...homeRow({ id: "m1", tags: undefined, ai_tags: undefined }),
+            vendors: null,
+          },
+        ],
+      }));
+    createClientMock.mockResolvedValue({ from });
+
+    await expect(getTrendingItems(2)).resolves.toEqual([
+      expect.objectContaining({
+        id: "m1",
+        tags: [],
+        ai_tags: [],
+        vendor_name: "",
+        vendor_is_open: true,
+      }),
+    ]);
+  });
+
   it("returns [] without querying menu items when there are no recent orders", async () => {
     const from = vi.fn().mockReturnValueOnce(makeThenable({ data: [] }));
     createClientMock.mockResolvedValue({ from });

--- a/lib/search.test.ts
+++ b/lib/search.test.ts
@@ -137,6 +137,28 @@ describe("searchHomeItems", () => {
     );
   });
 
+  it("degrades to keyword-only embedding when embed-query throws", async () => {
+    const invoke = vi.fn(async (name: string) => {
+      if (name === "embed-query") throw new Error("edge crashed");
+      return { data: null, error: null };
+    });
+    const rpc = vi.fn(async () => ({ data: [row("a", "A")], error: null }));
+    createClientMock.mockResolvedValue({ functions: { invoke }, rpc });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await searchHomeItems("拉麵");
+
+    expect(rpc).toHaveBeenCalledWith(
+      "hybrid_search",
+      expect.objectContaining({ p_query_embedding: null }),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "embed-query failed; degrading to keyword-only:",
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
   it("skips the reranker when there is at most one candidate", async () => {
     const { client, invoke } = makeClient({ rpcData: [row("a", "A")] });
     createClientMock.mockResolvedValue(client);
@@ -189,5 +211,27 @@ describe("searchHomeItems", () => {
     await searchHomeItems("飯", undefined, 10, { sort: "price_asc" });
 
     expect(invoke).not.toHaveBeenCalledWith("rerank-search", expect.anything());
+  });
+
+  it("keeps the RRF order when the reranker throws", async () => {
+    const invoke = vi.fn(async (name: string) => {
+      if (name === "embed-query") return { data: { embedding: [0.1, 0.2] }, error: null };
+      throw new Error("reranker crashed");
+    });
+    const rpc = vi.fn(async () => ({
+      data: [row("a", "A"), row("b", "B")],
+      error: null,
+    }));
+    createClientMock.mockResolvedValue({ functions: { invoke }, rpc });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await searchHomeItems("牛肉麵");
+
+    expect(result.map((i) => i.id)).toEqual(["a", "b"]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "rerank-search failed; keeping RRF order:",
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
   });
 });

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -48,4 +48,34 @@ describe("proxy", () => {
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toBe("https://example.test/admin");
   });
+
+  it("writes Supabase cookie updates to the request and response", async () => {
+    vi.resetModules();
+
+    vi.doMock("@supabase/ssr", () => ({
+      createServerClient: vi.fn((_url, _key, options) => ({
+        auth: {
+          getUser: vi.fn(async () => {
+            expect(options.cookies.getAll()).toEqual([
+              { name: "sb-session", value: "old" },
+            ]);
+            options.cookies.setAll([
+              { name: "sb-session", value: "fresh", options: { path: "/" } },
+            ]);
+            return { data: { user: null } };
+          }),
+        },
+        from: vi.fn(),
+      })),
+    }));
+    const { proxy: isolatedProxy } = await import("@/proxy");
+    const request = new NextRequest("https://example.test/auth/callback", {
+      headers: { Cookie: "sb-session=old" },
+    });
+
+    const res = await isolatedProxy(request);
+
+    expect(request.cookies.get("sb-session")?.value).toBe("fresh");
+    expect(res.cookies.get("sb-session")?.value).toBe("fresh");
+  });
 });


### PR DESCRIPTION
## Summary
- Add backend coverage for admin trend, cart, login, pickup, Sentry webhook, menu ordering, vendor menu callbacks, and recommendation/search/context/filter fallbacks.
- Cover key error branches such as missing records, invalid status, failed mutations, invalid webhook payloads, and edge-function fallback paths.

## Test plan
- [x] bun run lint
- [x] bun run test:coverage